### PR TITLE
ci: update GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/check-k3s-upgrade.yml
+++ b/.github/workflows/check-k3s-upgrade.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Get current version from config
         id: current
@@ -67,7 +67,7 @@ jobs:
       - name: Check for existing open upgrade issues
         if: steps.check.outputs.needed == 'true'
         id: existing
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const issues = await github.rest.issues.listForRepo({
@@ -95,7 +95,7 @@ jobs:
 
       - name: Create upgrade issue
         if: steps.check.outputs.needed == 'true' && steps.existing.outputs.exists == 'false'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const current = '${{ steps.current.outputs.version }}';

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/upgrade-k3s.yml
+++ b/.github/workflows/upgrade-k3s.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Close issue
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             await github.rest.issues.update({
@@ -44,11 +44,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Determine upgrade version
         id: version
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             let version;
@@ -156,7 +156,7 @@ jobs:
 
       - name: Comment and close issue
         if: github.event_name == 'issue_comment'
-        uses: actions/github-script@v7
+        uses: actions/github-script@v9
         with:
           script: |
             const version = '${{ steps.version.outputs.k3s_version }}';


### PR DESCRIPTION
## Summary

Updates all GitHub Actions across the workflows to Node.js 24 compatible versions, ahead of the Node.js 20 deprecation deadline on June 2nd, 2026.

## Changes

| Action | Before | After |
|---|---|---|
| `actions/checkout` | `v4` | `v6` |
| `actions/github-script` | `v7` | `v9` |

## Workflows updated
- `.github/workflows/lint.yml`
- `.github/workflows/upgrade-k3s.yml`
- `.github/workflows/check-k3s-upgrade.yml`

Closes #14