### PR TITLE
ci: only run ansible-lint on relevant file changes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened]
+    paths:
+      - 'linux/**'
+      - 'argocd/**'
+      - 'helm/**'
+      - 'requirements.yml'
+      - '.ansible-lint'
+      - '.github/workflows/lint.yml'
 
 jobs:
   ansible-lint:


### PR DESCRIPTION
## Summary

Adds a `paths` filter to the ansible-lint workflow so it only triggers when files relevant to the linted playbooks are changed, rather than on every PR.

## Paths watched

| Path | Reason |
|---|---|
| `linux/**` | `linux/baseline.yml` |
| `argocd/**` | `argocd/playbooks/argocd-setup.yml` |
| `helm/**` | `helm/playbooks/helm-install.yml` |
| `requirements.yml` | Collection dependencies affect all playbooks |
| `.ansible-lint` | Lint config changes affect all playbooks |
| `.github/workflows/lint.yml` | Workflow changes should always re-run |

Closes #17