### PR TITLE
fix: use printf to correctly write SSH private key in workflows

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -13,9 +13,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts
           if [ -n "${{ secrets.WORKER_NODE_IPS }}" ]; then
@@ -82,9 +84,11 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts
           if [ -n "${{ secrets.WORKER_NODE_IPS }}" ]; then

--- a/.github/workflows/upgrade-k3s.yml
+++ b/.github/workflows/upgrade-k3s.yml
@@ -68,9 +68,11 @@ jobs:
             core.setOutput('k3s_version', version);
 
       - name: Set up SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
           # Always scan the master node


### PR DESCRIPTION
## Summary

Fixes SSH key setup in `update-packages.yml` and `upgrade-k3s.yml` where `echo` was used to write the private key, which can corrupt multiline PEM keys by not preserving newlines correctly.

## Root cause

Using `echo "${{ secrets.SSH_PRIVATE_KEY }}"` directly in a `run` block interpolates the secret inline, which can cause issues with multiline values. The key is written incorrectly, causing SSH to reject it.

## Fix

Pass the secret as an environment variable and use `printf` to write it:

```bash
env:
  SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
run: |
  printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
```

This correctly preserves newlines in the PEM key format.

## Files changed
- `.github/workflows/update-packages.yml` — fixed in both `dry-run` and `apply` jobs
- `.github/workflows/upgrade-k3s.yml` — fixed in `upgrade` job

Closes #20