### PR TITLE
Add paths filter to Molecule workflow for linux scenario

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
     types: [opened, synchronize, reopened]
+    paths:
+      - 'linux/**'
+      - 'molecule/linux/**'
+      - '.github/workflows/molecule.yml'
+      - 'requirements.yml'
 
 jobs:
   molecule-linux:


### PR DESCRIPTION
## Summary

- Adds a `paths` filter to `.github/workflows/molecule.yml` so the Molecule test for `linux/baseline.yml` only runs when relevant files are changed
- Mirrors the same approach already used in the `ansible-lint` workflow

## Paths that trigger the workflow

- `linux/**`
- `molecule/linux/**`
- `.github/workflows/molecule.yml`
- `requirements.yml`

Closes #23