### PR TITLE
feat: add Tailscale setup playbooks and integrate with CI workflows

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -12,10 +12,18 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          args: --accept-routes
+
       - name: Set up SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts
           if [ -n "${{ secrets.WORKER_NODE_IPS }}" ]; then
@@ -81,10 +89,18 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v6
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          args: --accept-routes
+
       - name: Set up SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
           ssh-keyscan ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts
           if [ -n "${{ secrets.WORKER_NODE_IPS }}" ]; then

--- a/.github/workflows/upgrade-k3s.yml
+++ b/.github/workflows/upgrade-k3s.yml
@@ -67,10 +67,18 @@ jobs:
             }
             core.setOutput('k3s_version', version);
 
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v3
+        with:
+          authkey: ${{ secrets.TAILSCALE_AUTHKEY }}
+          args: --accept-routes
+
       - name: Set up SSH key
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
-          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
 
           # Always scan the master node

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ k3s/k3s-config-local.yml
 inventory/hosts-local.ini
 linux/inventory/hosts-local.ini
 argocd/vault/secrets-local.yml
+linux/vault/secrets-local.yml
 
 # Ansible vault password files (never commit these)
 .vault_pass

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -1,0 +1,108 @@
+# Tailscale Setup
+
+This document covers how to install and configure Tailscale on your homelab nodes using the Ansible playbooks in `linux/`.
+
+Tailscale creates a secure WireGuard-based mesh VPN between your devices. For this homelab it serves two purposes:
+
+- **Remote access** — reach your homelab nodes by Tailscale IP from anywhere without port forwarding
+- **GitHub Actions** — allows CI/CD workflows to SSH into homelab nodes from the public internet via `tailscale/github-action`
+
+## Prerequisites
+
+- Linux baseline applied (see [README](../README.md))
+- Tailscale account — sign up free at [https://tailscale.com](https://tailscale.com)
+
+## 1. Install Tailscale on the nodes
+
+Run the install playbook to add the Tailscale apt repository, install the package, and start the `tailscaled` service:
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-install.yml \
+  --ask-become-pass
+```
+
+The playbook will output a login URL for each node. Open each URL in your browser and log in with your Tailscale account to register the node.
+
+## 2. Install Tailscale on a second device
+
+> **Important:** Tailscale requires at least 2 devices registered in your account before you can generate an auth key. This is a known limitation — see [tailscale/tailscale#16217](https://github.com/tailscale/tailscale/issues/16217).
+
+Install Tailscale on your laptop or desktop and log in with the same Tailscale account:
+
+- **macOS:** `brew install tailscale` or download from [https://tailscale.com/download/mac](https://tailscale.com/download/mac)
+- **Windows:** [https://tailscale.com/download/windows](https://tailscale.com/download/windows)
+- **Linux:** [https://tailscale.com/download/linux](https://tailscale.com/download/linux)
+
+Once both devices are registered, your Tailscale admin console will be accessible at [https://login.tailscale.com/admin](https://login.tailscale.com/admin).
+
+## 3. Generate an auth key
+
+Go to [https://login.tailscale.com/admin/settings/keys](https://login.tailscale.com/admin/settings/keys) and create a new auth key with the following settings:
+
+- **Reusable** — so the same key works across multiple nodes and GitHub Actions runs
+- **Ephemeral** — GitHub Actions runners are automatically removed from your tailnet when the job finishes
+- **Expiry** — 90 days is a sensible default for a homelab
+
+Keep the key safe — you will add it to the Ansible vault and as a GitHub Actions secret.
+
+## 4. Authenticate the nodes
+
+Add your auth key to the vault:
+
+```bash
+cp linux/vault/secrets.yml linux/vault/secrets-local.yml
+# edit secrets-local.yml and replace the placeholder with your real auth key
+ansible-vault encrypt linux/vault/secrets-local.yml
+```
+
+Then run the auth playbook:
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-auth.yml \
+  --ask-become-pass --ask-vault-pass
+```
+
+The playbook will:
+- Authenticate each node to your Tailscale account using the auth key
+- Open UFW to allow Tailscale traffic (`41641/udp` and the `tailscale0` interface)
+- Print the Tailscale IP for each node at the end of the run
+
+The output will look like this:
+
+```
+ok: [192.168.50.x] => {
+    "msg": "Tailscale IP for 192.168.50.x: 100.64.0.1"
+}
+```
+
+> The IP on the left (`192.168.50.x`) is your node's local network IP — this is just how Ansible identifies the host from your inventory. The IP on the right (`100.64.0.1`) is the Tailscale IP. **This is the one you need** — use it to update `MASTER_NODE_IP` in your GitHub Actions secrets.
+
+## 5. Configure GitHub Actions secrets
+
+Update the following secrets in your repository at [https://github.com/denisecodes/k3s-homelab/settings/secrets/actions](https://github.com/denisecodes/k3s-homelab/settings/secrets/actions):
+
+| Secret | Value |
+|--------|-------|
+| `TAILSCALE_AUTHKEY` | The auth key generated in step 3 |
+| `MASTER_NODE_IP` | Your master node's Tailscale IP (e.g. `100.x.x.x`) |
+| `WORKER_NODE_IPS` | Your worker node Tailscale IPs, comma-separated (if applicable) |
+
+## Verify
+
+Check that your nodes are visible and connected in the Tailscale admin console:
+
+```
+https://login.tailscale.com/admin/machines
+```
+
+Or from the node directly:
+
+```bash
+tailscale status
+```
+
+## Configuration reference
+
+| Variable | File | Description |
+|----------|------|-------------|
+| `tailscale_authkey` | `linux/vault/secrets-local.yml` | Pre-auth key for authenticating nodes to your tailnet |

--- a/linux/tailscale-auth.yml
+++ b/linux/tailscale-auth.yml
@@ -1,0 +1,56 @@
+---
+# Authenticates nodes to Tailscale and configures UFW rules.
+# Requires Tailscale to already be installed — run linux/tailscale-install.yml first.
+# See docs/tailscale.md for the full setup guide including auth key generation.
+#
+# Before running:
+#   cp linux/vault/secrets.yml linux/vault/secrets-local.yml
+#   # edit secrets-local.yml with your real Tailscale auth key, then:
+#   ansible-vault encrypt linux/vault/secrets-local.yml
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-auth.yml \
+#     --ask-become-pass --ask-vault-pass
+
+- name: Authenticate Tailscale and configure UFW
+  hosts: homelab
+  become: true
+  vars_files:
+    - "{{ lookup('first_found', ['vault/secrets-local.yml', 'vault/secrets.yml']) }}"
+
+  tasks:
+    - name: Check if already authenticated to Tailscale
+      ansible.builtin.command: tailscale status --json
+      register: tailscale_status
+      changed_when: false
+      failed_when: false
+
+    - name: Authenticate to Tailscale
+      ansible.builtin.command: >
+        tailscale up --authkey={{ tailscale_authkey }} --accept-routes
+      when: >
+        (tailscale_status.rc != 0) or
+        ('NeedsLogin' in tailscale_status.stdout)
+      changed_when: true
+      no_log: true
+
+    - name: Allow Tailscale UDP port through UFW
+      community.general.ufw:
+        rule: allow
+        port: 41641
+        proto: udp
+
+    - name: Allow all traffic on tailscale0 interface
+      community.general.ufw:
+        rule: allow
+        interface: tailscale0
+        direction: in
+
+    - name: Get Tailscale IP
+      ansible.builtin.command: tailscale ip -4
+      register: tailscale_ip
+      changed_when: false
+
+    - name: Display Tailscale IP
+      ansible.builtin.debug:
+        msg: "Tailscale IP for {{ inventory_hostname }}: {{ tailscale_ip.stdout }}"

--- a/linux/tailscale-install.yml
+++ b/linux/tailscale-install.yml
@@ -1,0 +1,76 @@
+---
+# Installs Tailscale and starts the tailscaled service on all homelab nodes.
+# See docs/tailscale.md for the full setup guide including auth key generation.
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-install.yml \
+#     --ask-become-pass
+
+- name: Install Tailscale
+  hosts: homelab
+  become: true
+
+  tasks:
+    - name: Add Tailscale apt signing key
+      ansible.builtin.get_url:
+        url: https://pkgs.tailscale.com/stable/ubuntu/noble.noarmor.gpg
+        dest: /usr/share/keyrings/tailscale-archive-keyring.gpg
+        mode: '0644'
+
+    - name: Add Tailscale apt repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/usr/share/keyrings/tailscale-archive-keyring.gpg] https://pkgs.tailscale.com/stable/ubuntu noble main"
+        filename: tailscale
+        state: present
+
+    - name: Install Tailscale
+      ansible.builtin.apt:
+        name: tailscale
+        state: present
+        update_cache: true
+
+    - name: Enable and start tailscaled service
+      ansible.builtin.service:
+        name: tailscaled
+        enabled: true
+        state: started
+
+    - name: Check if already authenticated to Tailscale
+      ansible.builtin.command: tailscale status --json
+      register: tailscale_status
+      changed_when: false
+      failed_when: false
+
+    - name: Start tailscale up to generate login URL
+      ansible.builtin.command: tailscale up
+      async: 60
+      poll: 0
+      changed_when: true
+      when: >
+        (tailscale_status.rc != 0) or
+        ('NeedsLogin' in tailscale_status.stdout)
+
+    - name: Wait for login URL to be available
+      ansible.builtin.pause:
+        seconds: 3
+      when: >
+        (tailscale_status.rc != 0) or
+        ('NeedsLogin' in tailscale_status.stdout)
+
+    - name: Retrieve Tailscale login URL
+      ansible.builtin.command: tailscale status --json
+      register: tailscale_status_after
+      changed_when: false
+      failed_when: false
+      when: >
+        (tailscale_status.rc != 0) or
+        ('NeedsLogin' in tailscale_status.stdout)
+
+    - name: Display Tailscale login URL
+      ansible.builtin.debug:
+        msg: >-
+          Open this URL in your browser to authenticate this node:
+          {{ (tailscale_status_after.stdout | from_json).AuthURL | default('URL not yet available — run: sudo tailscale status') }}
+      when: >
+        tailscale_status_after is not skipped and
+        (tailscale_status_after.stdout | from_json).AuthURL is defined

--- a/linux/vault/secrets.yml
+++ b/linux/vault/secrets.yml
@@ -1,0 +1,2 @@
+# vault/secrets.yml  — encrypt with: ansible-vault encrypt linux/vault/secrets.yml
+tailscale_authkey: "tskey-auth-REPLACE_ME"


### PR DESCRIPTION
## Summary

- Adds `linux/tailscale-install.yml` to install Tailscale on homelab nodes and register them via browser login
- Adds `linux/tailscale-auth.yml` to authenticate nodes via auth key, configure UFW rules, and output the Tailscale IP
- Adds `linux/vault/secrets.yml` placeholder for the Tailscale auth key
- Adds `docs/tailscale.md` with full setup guide, including the 2-device requirement for auth key generation and example playbook output showing which IP to use for GitHub Actions secrets
- Adds `tailscale/github-action@v3` step to `update-packages.yml` and `upgrade-k3s.yml` so GitHub Actions runners can reach homelab nodes over Tailscale
- Fixes SSH key writing in both workflows using `printf` instead of `echo` (supersedes PR #21)
- Updates `.gitignore` to exclude `linux/vault/secrets-local.yml`

## Testing

- `tailscale-install.yml` run successfully against homelab node — node registered and visible in Tailscale admin console
- `tailscale-auth.yml` run successfully — node authenticated, UFW rules applied, Tailscale IP confirmed as `100.110.67.56`
- `MASTER_NODE_IP` and `TAILSCALE_AUTHKEY` GitHub Actions secrets updated to use Tailscale IP

Closes #22