### PR TITLE
fix: add NOPASSWD sudoers for ansible user and rename update-packages workflow

### DIFF
--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -25,11 +25,15 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts
+          for i in 1 2 3 4 5; do
+            ssh-keyscan -T 10 ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts && break
+            echo "ssh-keyscan attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
           if [ -n "${{ secrets.WORKER_NODE_IPS }}" ]; then
             echo "${{ secrets.WORKER_NODE_IPS }}" | tr ',' '\n' | while read -r ip; do
               ip=$(echo "$ip" | tr -d ' ')
-              [ -n "$ip" ] && ssh-keyscan "$ip" >> ~/.ssh/known_hosts
+              [ -n "$ip" ] && ssh-keyscan -T 10 "$ip" >> ~/.ssh/known_hosts
             done
           fi
 
@@ -102,11 +106,15 @@ jobs:
           mkdir -p ~/.ssh
           printf '%s\n' "$SSH_PRIVATE_KEY" > ~/.ssh/id_ed25519
           chmod 600 ~/.ssh/id_ed25519
-          ssh-keyscan ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts
+          for i in 1 2 3 4 5; do
+            ssh-keyscan -T 10 ${{ secrets.MASTER_NODE_IP }} >> ~/.ssh/known_hosts && break
+            echo "ssh-keyscan attempt $i failed, retrying in 10s..."
+            sleep 10
+          done
           if [ -n "${{ secrets.WORKER_NODE_IPS }}" ]; then
             echo "${{ secrets.WORKER_NODE_IPS }}" | tr ',' '\n' | while read -r ip; do
               ip=$(echo "$ip" | tr -d ' ')
-              [ -n "$ip" ] && ssh-keyscan "$ip" >> ~/.ssh/known_hosts
+              [ -n "$ip" ] && ssh-keyscan -T 10 "$ip" >> ~/.ssh/known_hosts
             done
           fi
 

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -1,4 +1,4 @@
-name: Safe package updates
+name: Update packages
 
 on:
   schedule:

--- a/linux/baseline.yml
+++ b/linux/baseline.yml
@@ -57,6 +57,14 @@
       community.general.timezone:
         name: "{{ timezone | default('UTC') }}"
 
+    - name: Configure passwordless sudo for Ansible user
+      ansible.builtin.lineinfile:
+        path: /etc/sudoers.d/{{ ansible_user }}
+        line: "{{ ansible_user }} ALL=(ALL) NOPASSWD:ALL"
+        create: true
+        mode: '0440'
+        validate: 'visudo -cf %s'
+
     # ── LVM: expand logical volume to use all available disk space ─────
     # Ubuntu Server's default installer only allocates ~100GB even on larger
     # disks. These tasks extend the logical volume and resize the filesystem


### PR DESCRIPTION
## Summary

- Adds a `NOPASSWD` sudoers entry for the Ansible user in `linux/baseline.yml` so CI can run `become` tasks without a password prompt
- Renames the `Safe package updates` workflow to `Update packages` for consistency

## Testing

- `linux/baseline.yml` verified locally against homelab node
- CI run on this branch will confirm `Update packages` workflow passes end-to-end via Tailscale

Closes #46