### PR TITLE
chore: standardise local config setup with cp instructions and <YOUR_*> placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,14 @@ git submodule update --init --recursive
 
 ### 4. Update the inventory
 
-Edit `linux/inventory/hosts.ini` and fill in your details. The inventory is split into `[master]` and `[workers]` groups so the playbook can apply different rules to each (e.g. port 6443 is only opened on the master).
+Copy the inventory template and fill in your details:
+
+```bash
+cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+# edit hosts-local.ini with your real IPs, username, and timezone
+```
+
+The inventory is split into `[master]` and `[workers]` groups so the playbook can apply different rules to each (e.g. port 6443 is only opened on the master).
 
 **Single node:**
 
@@ -126,7 +133,7 @@ Set `timezone` to your local timezone. You can find the correct string at [https
 ### 5. Run the Ansible playbook
 
 ```bash
-ansible-playbook -i linux/inventory/hosts.ini linux/baseline.yml --ask-become-pass
+ansible-playbook -i linux/inventory/hosts-local.ini linux/baseline.yml --ask-become-pass
 ```
 
 You will be prompted for the become (sudo) password of the remote user. The playbook will then:
@@ -139,7 +146,12 @@ You will be prompted for the become (sudo) password of the remote user. The play
 
 ### 6. Configure K3s
 
-Edit `k3s/k3s-config.yml` and fill in your details:
+Copy the K3s config template and fill in your details:
+
+```bash
+cp k3s/k3s-config.yml k3s/k3s-config-local.yml
+# edit k3s-config-local.yml with your real IPs, username, and token
+```
 
 **Single node (default):**
 
@@ -199,7 +211,7 @@ For both setups, replace the following placeholders:
 ### 7. Install K3s
 
 ```bash
-ansible-playbook -i k3s/k3s-config.yml k3s-ansible/playbooks/site.yml --ask-become-pass
+ansible-playbook -i k3s/k3s-config-local.yml k3s-ansible/playbooks/site.yml --ask-become-pass
 ```
 
 You will be prompted for the become (sudo) password. This will install and configure K3s on your server.

--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -17,7 +17,7 @@
   hosts: homelab
   become: true
   vars_files:
-    - "{{ lookup('first_found', ['../vault/secrets-local.yml', '../vault/secrets.yml']) }}"
+    - "../vault/secrets-local.yml"
 
   vars:
     argocd_chart_version: "7.8.28"   # https://artifacthub.io/packages/helm/argo/argo-cd

--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -1,14 +1,16 @@
 ---
 # Before running:
-#   ansible-galaxy collection install -r requirements.yml
+#   cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+#   # edit hosts-local.ini with your real IPs, username, and timezone
+#
 #   cp argocd/vault/secrets.yml argocd/vault/secrets-local.yml
-#   # edit secrets-local.yml with your real password (gitignored), then:
+#   # edit secrets-local.yml with your real password, then:
 #   ansible-vault encrypt argocd/vault/secrets-local.yml
-#   # secrets-local.yml is used automatically if present, otherwise secrets.yml is used
-#   ansible-playbook -i linux/inventory/hosts.ini helm/playbooks/helm-install.yml --ask-become-pass
+#
+#   ansible-galaxy collection install -r requirements.yml
 #
 # Run with:
-#   ansible-playbook -i linux/inventory/hosts.ini argocd/playbooks/argocd-setup.yml \
+#   ansible-playbook -i linux/inventory/hosts-local.ini argocd/playbooks/argocd-setup.yml \
 #     --ask-become-pass --ask-vault-pass
 
 - name: Install and configure ArgoCD via Helm

--- a/argocd/vault/secrets.yml
+++ b/argocd/vault/secrets.yml
@@ -1,2 +1,5 @@
-# vault/secrets.yml  — encrypt with: ansible-vault encrypt vault/secrets.yml
-argocd_user_password: "YourStrongPasswordHere"
+# vault/secrets.yml — template only, do not edit directly
+# cp argocd/vault/secrets.yml argocd/vault/secrets-local.yml
+# edit secrets-local.yml with your real password, then:
+# ansible-vault encrypt argocd/vault/secrets-local.yml
+argocd_user_password: "<YOUR_ARGOCD_PASSWORD>"

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -24,7 +24,7 @@ ansible-galaxy collection install -r argocd/requirements.yml
 
 ## 2. Create and encrypt the vault secrets file
 
-The playbook reads `argocd/vault/secrets.yml` to set the password for your dedicated ArgoCD user. This file must exist **before** encrypting it.
+The playbook reads `argocd/vault/secrets-local.yml` to set the password for your dedicated ArgoCD user.
 
 First, set your desired username by editing the `argocd_user` variable at the top of `argocd/playbooks/argocd-setup.yml`:
 
@@ -33,28 +33,28 @@ vars:
   argocd_user: "your-username"   # change this to whatever you want
 ```
 
-The file is already scaffolded in the repo with a placeholder value. Edit it first:
+Copy the template and fill in your real password:
 
 ```bash
-# Open the file and replace the placeholder with a real strong password
-vim argocd/vault/secrets.yml
+cp argocd/vault/secrets.yml argocd/vault/secrets-local.yml
+# edit secrets-local.yml — replace <YOUR_ARGOCD_PASSWORD> with a real strong password
 ```
 
-It should look like this (before encryption):
+It should look like this before encryption:
 
 ```yaml
-argocd_user_password: "YourStrongPasswordHere"  # replace with a real strong password
+argocd_user_password: "a-real-strong-password"
 ```
 
-Once you have set a real password, encrypt the file with ansible-vault:
+Once you have set a real password, encrypt it with ansible-vault:
 
 ```bash
-ansible-vault encrypt argocd/vault/secrets.yml
+ansible-vault encrypt argocd/vault/secrets-local.yml
 ```
 
 You will be prompted to set a vault password. Keep this safe — you will need it every time you run the playbook.
 
-> **Never commit the unencrypted file.** The file is encrypted in-place; the ciphertext is safe to commit.
+> **Never commit `secrets-local.yml` unencrypted.** It is gitignored — the template `secrets.yml` (with the placeholder) is what is committed.
 
 ## 3. Run the playbook
 

--- a/helm/playbooks/helm-install.yml
+++ b/helm/playbooks/helm-install.yml
@@ -1,8 +1,12 @@
 ---
 # Installs Helm (the Kubernetes package manager) on the target hosts.
 #
+# Before running:
+#   cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+#   # edit hosts-local.ini with your real IPs, username, and timezone
+#
 # Run with:
-#   ansible-playbook -i linux/inventory/hosts.ini helm/playbooks/helm-install.yml \
+#   ansible-playbook -i linux/inventory/hosts-local.ini helm/playbooks/helm-install.yml \
 #     --ask-become-pass
 
 - name: Install Helm

--- a/linux/baseline.yml
+++ b/linux/baseline.yml
@@ -1,4 +1,10 @@
 ---
+# Before running:
+#   cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+#   # edit hosts-local.ini with your real IPs, username, and timezone
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/baseline.yml --ask-become-pass
 - name: Baseline server setup
   hosts: homelab
   become: true

--- a/linux/tailscale-auth.yml
+++ b/linux/tailscale-auth.yml
@@ -16,7 +16,7 @@
   hosts: homelab
   become: true
   vars_files:
-    - "{{ lookup('first_found', ['vault/secrets-local.yml', 'vault/secrets.yml']) }}"
+    - "vault/secrets-local.yml"
 
   tasks:
     - name: Check if already authenticated to Tailscale

--- a/linux/update-packages.yml
+++ b/linux/update-packages.yml
@@ -1,4 +1,11 @@
 ---
+# Before running:
+#   cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+#   # edit hosts-local.ini with your real IPs, username, and timezone
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/update-packages.yml \
+#     --ask-become-pass
 - name: Safe package updates
   hosts: homelab
   become: true


### PR DESCRIPTION
## Summary

- `argocd/vault/secrets.yml` — replaced `YourStrongPasswordHere` with `<YOUR_ARGOCD_PASSWORD>` and added `cp` instructions in the file header
- `linux/baseline.yml` — added `cp` instruction header so users know to create `hosts-local.ini` before running
- `docs/argocd.md` — updated vault setup section to use `cp` + `<YOUR_*>` pattern instead of editing the template directly
- `README.md` — added `cp` instructions for `hosts.ini` → `hosts-local.ini` and `k3s-config.yml` → `k3s-config-local.yml`, updated all playbook run commands to use the `-local` files

Closes #45