### PR TITLE
chore: move linux playbooks into playbooks/ subfolder and rename baseline.yml to server-setup.yml

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,4 +29,4 @@ jobs:
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Lint playbooks
-        run: ansible-lint linux/baseline.yml argocd/playbooks/argocd-setup.yml helm/playbooks/helm-install.yml
+        run: ansible-lint linux/playbooks/server-setup.yml argocd/playbooks/argocd-setup.yml helm/playbooks/helm-install.yml

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -24,6 +24,6 @@ jobs:
       - name: Install required collections
         run: ansible-galaxy collection install -r requirements.yml
 
-      - name: Run Molecule tests for linux/baseline.yml
+      - name: Run Molecule tests for linux/playbooks/server-setup.yml
         run: molecule test --scenario-name linux
         working-directory: ${{ github.workspace }}

--- a/.github/workflows/update-packages.yml
+++ b/.github/workflows/update-packages.yml
@@ -81,7 +81,7 @@ jobs:
 
       - name: Dry run - show packages that would be upgraded
         run: |
-          ansible-playbook linux/update-packages.yml \
+          ansible-playbook linux/playbooks/update-packages.yml \
             -i runtime-inventory.ini \
             --check \
             --diff
@@ -162,7 +162,7 @@ jobs:
 
       - name: Apply package updates
         run: |
-          ansible-playbook linux/update-packages.yml \
+          ansible-playbook linux/playbooks/update-packages.yml \
             -i runtime-inventory.ini
 
       - name: Open issue on failure

--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Set `timezone` to your local timezone. You can find the correct string at [https
 ### 5. Run the Ansible playbook
 
 ```bash
-ansible-playbook -i linux/inventory/hosts-local.ini linux/baseline.yml --ask-become-pass
+ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/server-setup.yml --ask-become-pass
 ```
 
 You will be prompted for the become (sudo) password of the remote user. The playbook will then:

--- a/docs/future-improvements.md
+++ b/docs/future-improvements.md
@@ -33,7 +33,7 @@ Add a GitHub Actions workflow (`.github/workflows/code-review.yml`) that runs on
 Add a GitHub Actions workflow (`.github/workflows/lint.yml`) that runs `ansible-lint` on every pull request targeting `main`. This catches syntax errors, deprecated module usage, and best practice violations before the PR can be merged. Enforce it as a required status check in branch protection.
 
 Playbooks to lint:
-- `linux/baseline.yml`
+- `linux/playbooks/server-setup.yml`
 - `k3s/k3s-config.yml` (inventory/vars file — skip if not a playbook)
 - `argocd/playbooks/argocd-setup.yml`
 - `k3s-ansible/playbooks/site.yml` and `k3s-ansible/playbooks/upgrade.yml` (submodule — may need to pin lint rules)
@@ -42,7 +42,7 @@ Playbooks to lint:
 
 Add Molecule scenarios that run on every pull request targeting `main`, alongside ansible-lint, as required status checks before merging. Use [Molecule](https://ansible.readthedocs.io/projects/molecule/) with the Docker driver to test each playbook in isolation. Each scenario spins up a container, runs the playbook, and asserts expected state using `ansible.builtin.assert` or `testinfra`.
 
-#### `linux/baseline.yml`
+#### `linux/playbooks/server-setup.yml`
 
 Scenario: `molecule/linux/`
 
@@ -106,7 +106,7 @@ Once the playbook exists, the `upgrade-k3s.yml` GitHub Actions workflow can be e
 Add a scheduled GitHub Actions workflow (e.g. monthly) to run `apt update && apt upgrade` on the homelab servers via Ansible. This keeps packages up to date without requiring manual SSH access.
 
 - Trigger: `schedule` (e.g. first Sunday of month) + `workflow_dispatch` for manual runs
-- Playbook: reuse `linux/baseline.yml` or extract a dedicated `linux/update-packages.yml`
+- Playbook: reuse `linux/playbooks/server-setup.yml` or extract a dedicated `linux/playbooks/update-packages.yml`
 - The workflow should open a GitHub issue or send a notification on failure
 - Consider a `--check` dry-run step first to show what would be upgraded before applying
 
@@ -114,7 +114,7 @@ Add a scheduled GitHub Actions workflow (e.g. monthly) to run `apt update && apt
 
 Add dedicated workflows to provision each layer of the cluster from scratch via GitHub Actions, mirroring what is currently done manually via the terminal. Each workflow should be a separate file and triggered independently (e.g. `workflow_dispatch`) so they can be run in order or re-run individually if a step fails.
 
-- **`provision-linux.yml`** — runs `linux/baseline.yml` against the inventory; requires secrets `SSH_PRIVATE_KEY`, `MASTER_NODE_IP`, `ANSIBLE_USER`
+- **`provision-linux.yml`** — runs `linux/playbooks/server-setup.yml` against the inventory; requires secrets `SSH_PRIVATE_KEY`, `MASTER_NODE_IP`, `ANSIBLE_USER`
 - **`provision-k3s.yml`** — generates `runtime-k3s-config.yml` from secrets and runs `k3s-ansible/playbooks/site.yml` to install the cluster; requires `SSH_PRIVATE_KEY`, `MASTER_NODE_IP`, `WORKER_NODE_IPS`, `ANSIBLE_USER`, `K3S_TOKEN`
 - **`provision-argocd.yml`** — installs the `kubernetes.core` collection, decrypts `argocd/vault/secrets.yml` using an `ANSIBLE_VAULT_PASSWORD` secret, and runs `argocd/playbooks/argocd-setup.yml`
 

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -17,7 +17,7 @@ Tailscale creates a secure WireGuard-based mesh VPN between your devices. For th
 Run the install playbook to add the Tailscale apt repository, install the package, and start the `tailscaled` service:
 
 ```bash
-ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-install.yml \
+ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/tailscale-install.yml \
   --ask-become-pass
 ```
 
@@ -58,7 +58,7 @@ ansible-vault encrypt linux/vault/secrets-local.yml
 Then run the auth playbook:
 
 ```bash
-ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-auth.yml \
+ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/tailscale-auth.yml \
   --ask-become-pass --ask-vault-pass
 ```
 

--- a/linux/playbooks/server-setup.yml
+++ b/linux/playbooks/server-setup.yml
@@ -4,7 +4,7 @@
 #   # edit hosts-local.ini with your real IPs, username, and timezone
 #
 # Run with:
-#   ansible-playbook -i linux/inventory/hosts-local.ini linux/baseline.yml --ask-become-pass
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/server-setup.yml --ask-become-pass
 - name: Baseline server setup
   hosts: homelab
   become: true

--- a/linux/playbooks/tailscale-auth.yml
+++ b/linux/playbooks/tailscale-auth.yml
@@ -1,6 +1,6 @@
 ---
 # Authenticates nodes to Tailscale and configures UFW rules.
-# Requires Tailscale to already be installed — run linux/tailscale-install.yml first.
+# Requires Tailscale to already be installed — run linux/playbooks/tailscale-install.yml first.
 # See docs/tailscale.md for the full setup guide including auth key generation.
 #
 # Before running:
@@ -9,7 +9,7 @@
 #   ansible-vault encrypt linux/vault/secrets-local.yml
 #
 # Run with:
-#   ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-auth.yml \
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/tailscale-auth.yml \
 #     --ask-become-pass --ask-vault-pass
 
 - name: Authenticate Tailscale and configure UFW

--- a/linux/playbooks/tailscale-install.yml
+++ b/linux/playbooks/tailscale-install.yml
@@ -3,7 +3,7 @@
 # See docs/tailscale.md for the full setup guide including auth key generation.
 #
 # Run with:
-#   ansible-playbook -i linux/inventory/hosts-local.ini linux/tailscale-install.yml \
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/tailscale-install.yml \
 #     --ask-become-pass
 
 - name: Install Tailscale

--- a/linux/playbooks/update-packages.yml
+++ b/linux/playbooks/update-packages.yml
@@ -4,7 +4,7 @@
 #   # edit hosts-local.ini with your real IPs, username, and timezone
 #
 # Run with:
-#   ansible-playbook -i linux/inventory/hosts-local.ini linux/update-packages.yml \
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/update-packages.yml \
 #     --ask-become-pass
 - name: Safe package updates
   hosts: homelab

--- a/molecule/linux/converge.yml
+++ b/molecule/linux/converge.yml
@@ -1,3 +1,3 @@
 ---
 - name: Converge
-  import_playbook: ../../linux/baseline.yml
+  import_playbook: ../../linux/playbooks/server-setup.yml


### PR DESCRIPTION
## Summary

- Moved `linux/baseline.yml`, `tailscale-install.yml`, `tailscale-auth.yml`, and `update-packages.yml` into `linux/playbooks/` to match the structure of `argocd/` and `helm/`
- Renamed `baseline.yml` to `server-setup.yml` for clarity
- Updated all references in docs, GitHub Actions workflows, Molecule converge, and playbook inline comments

Closes #56