### PR TITLE
feat: add Traefik ingress, local DNS via dnsmasq, and ingress validation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,6 +9,7 @@ on:
       - 'linux/**'
       - 'argocd/**'
       - 'helm/**'
+      - 'traefik/**'
       - 'requirements.yml'
       - '.ansible-lint'
       - '.github/workflows/lint.yml'
@@ -29,4 +30,4 @@ jobs:
         run: ansible-galaxy collection install -r requirements.yml
 
       - name: Lint playbooks
-        run: ansible-lint linux/playbooks/server-setup.yml argocd/playbooks/argocd-setup.yml helm/playbooks/helm-install.yml
+        run: ansible-lint linux/playbooks/server-setup.yml argocd/playbooks/argocd-setup.yml helm/playbooks/helm-install.yml traefik/playbooks/traefik-setup.yml

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -1,0 +1,104 @@
+# Local DNS Setup
+
+This document covers how to set up local DNS so homelab services are reachable by hostname (e.g. `gitea.home.lan`) instead of IP and port.
+
+## How it works
+
+[dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) runs on the homelab server and provides wildcard DNS resolution:
+
+- Any `*.home.lan` query resolves to the server's LAN IP
+- All other DNS queries are forwarded to upstream resolvers (Cloudflare `1.1.1.1` and Google `8.8.8.8`)
+- The router's DHCP hands out the server's IP as the DNS server for all LAN clients
+
+This means new apps automatically get DNS — no per-app DNS entries needed.
+
+## Prerequisites
+
+- Linux baseline applied (see [README](../README.md))
+- Server has a static IP or DHCP reservation on your router
+
+## 1. Install dnsmasq
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/dnsmasq-setup.yml \
+  --ask-become-pass
+```
+
+The playbook will:
+- Install dnsmasq
+- Disable systemd-resolved (frees port 53)
+- Configure wildcard DNS for `*.home.lan`
+- Set upstream DNS forwarders (Cloudflare + Google)
+- Open UFW ports 53/tcp and 53/udp
+- Verify DNS resolution is working
+
+## 2. Configure your router
+
+Update your router's DHCP settings to hand out the server's IP as the DNS server for all LAN clients.
+
+### ASUS RT-AX59U (via app)
+
+1. Open the **ASUS Router** app on your phone
+2. Go to **Settings > LAN > DHCP Server**
+3. Under **DNS and WINS Server Setting**, set **DNS Server 1** to your server's LAN IP (e.g. `192.168.1.100`)
+4. Optionally set **DNS Server 2** to `1.1.1.1` as a fallback
+5. Tap **Apply**
+
+### ASUS RT-AX59U (via web panel)
+
+1. Open `http://192.168.1.1` in your browser
+2. Log in with your router admin credentials
+3. Go to **LAN** in the left sidebar, then the **DHCP Server** tab
+4. Under **DNS and WINS Server Setting**, set **DNS Server 1** to your server's LAN IP
+5. Optionally set **DNS Server 2** to `1.1.1.1`
+6. Click **Apply**
+
+### Other routers
+
+Look for **DHCP Server** settings in your router's admin panel. Set the **DNS Server** field to your homelab server's LAN IP.
+
+## 3. Renew DHCP on your devices
+
+After updating the router, devices need to renew their DHCP lease to pick up the new DNS server:
+
+- **macOS:** Toggle Wi-Fi off/on, or run `sudo ipconfig set en0 DHCP`
+- **Linux:** `sudo dhclient -r && sudo dhclient`
+- **Windows:** `ipconfig /release && ipconfig /renew`
+- **iOS:** Settings > Wi-Fi > tap your network > Renew Lease
+
+## 4. Verify from a client device
+
+From any device on your LAN:
+
+```bash
+nslookup whoami.home.lan
+```
+
+This should return your server's LAN IP. If it doesn't, check that:
+- dnsmasq is running on the server: `sudo systemctl status dnsmasq`
+- The router DHCP is handing out the correct DNS: check your device's DNS settings
+- UFW is allowing port 53: `sudo ufw status`
+
+## Configuration
+
+Key variables in `linux/playbooks/dnsmasq-setup.yml`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `homelab_domain` | `home.lan` | Wildcard domain for local services |
+| `upstream_dns_1` | `1.1.1.1` | Primary upstream DNS (Cloudflare) |
+| `upstream_dns_2` | `8.8.8.8` | Secondary upstream DNS (Google) |
+
+## Troubleshooting
+
+**dnsmasq won't start (port 53 in use):**
+```bash
+sudo ss -tlnp | grep :53
+```
+If systemd-resolved is still running, stop it: `sudo systemctl stop systemd-resolved`
+
+**DNS works on the server but not from other devices:**
+Check that UFW allows port 53 and that your router DHCP is pointing to the server IP.
+
+**DNS queries are slow:**
+Check the dnsmasq log: `sudo tail -f /var/log/dnsmasq.log`. Ensure upstream DNS servers are reachable: `dig google.com @1.1.1.1`

--- a/docs/future-improvements.md
+++ b/docs/future-improvements.md
@@ -34,6 +34,8 @@ Add a GitHub Actions workflow (`.github/workflows/lint.yml`) that runs `ansible-
 
 Playbooks to lint:
 - `linux/playbooks/server-setup.yml`
+- `linux/playbooks/dnsmasq-setup.yml`
+- `traefik/playbooks/traefik-setup.yml`
 - `k3s/k3s-config.yml` (inventory/vars file — skip if not a playbook)
 - `argocd/playbooks/argocd-setup.yml`
 - `k3s-ansible/playbooks/site.yml` and `k3s-ansible/playbooks/upgrade.yml` (submodule — may need to pin lint rules)
@@ -129,6 +131,7 @@ k3s-homelab/
 ├── linux/              # Initial Ubuntu server setup (baseline.yml, inventory/)
 ├── k3s/                # K3s configuration (k3s-config.yml)
 ├── argocd/             # ArgoCD setup
+├── traefik/            # Traefik ingress controller setup
 ├── k3s-ansible/        # Submodule
 ├── .github/workflows/  # GitHub Actions workflows
 └── docs/               # Documentation

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -1,0 +1,90 @@
+# Traefik Setup
+
+This document covers how to install Traefik as the ingress controller for the K3s cluster and validate that it routes traffic correctly.
+
+## Background
+
+K3s ships with Traefik by default, but this homelab disables it (`--disable traefik` in `k3s/k3s-config.yml`) to allow custom configuration via Helm. This playbook installs Traefik from the official Helm chart with sensible defaults for a homelab.
+
+## Prerequisites
+
+- K3s cluster running (see [README](../README.md))
+- Helm installed (see [docs/helm.md](helm.md))
+- `kubernetes.core` collection installed:
+  ```bash
+  ansible-galaxy collection install -r requirements.yml
+  ```
+
+## 1. Install Traefik
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini traefik/playbooks/traefik-setup.yml \
+  --ask-become-pass
+```
+
+The playbook will:
+- Add the Traefik Helm repository
+- Install Traefik in the `traefik` namespace
+- Configure HTTP (port 80) and HTTPS (port 443) entrypoints
+- Use K3s ServiceLB to assign an external IP from the node
+- Enable the Traefik dashboard (internal only)
+
+## 2. Verify the installation
+
+Check that Traefik is running and has an external IP:
+
+```bash
+kubectl get svc -n traefik
+```
+
+You should see the `traefik` service with `TYPE: LoadBalancer` and an `EXTERNAL-IP` matching your node IP.
+
+## 3. Access the dashboard
+
+The Traefik dashboard is not exposed externally. Use port-forwarding to access it:
+
+```bash
+kubectl port-forward -n traefik deploy/traefik 9000:9000
+```
+
+Then open [http://localhost:9000/dashboard/](http://localhost:9000/dashboard/) in your browser.
+
+## 4. Validate with a test app
+
+After setting up local DNS (see [docs/dns.md](dns.md)), run the validation playbook:
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini traefik/playbooks/traefik-test.yml \
+  --ask-become-pass
+```
+
+This deploys a `whoami` test app with a Traefik IngressRoute at `whoami.home.lan`, validates that:
+
+1. Traefik routes HTTP traffic to the app
+2. DNS resolves `whoami.home.lan` to the server IP
+3. End-to-end request via hostname works
+
+The playbook automatically cleans up the test resources when done.
+
+To run only the cleanup (if a previous run failed mid-way):
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini traefik/playbooks/traefik-test.yml \
+  --ask-become-pass --tags cleanup
+```
+
+## Configuration
+
+Key variables in `traefik/playbooks/traefik-setup.yml`:
+
+| Variable | Default | Description |
+|---|---|---|
+| `traefik_chart_version` | `36.4.0` | Traefik Helm chart version |
+| `traefik_namespace` | `traefik` | Kubernetes namespace |
+| `homelab_domain` | `home.lan` | Local domain for services |
+
+## Future plans
+
+- Migrate Traefik to an ArgoCD-managed application in the `k3s-apps` repo
+- Add TLS with cert-manager (see issue F-5)
+- Add Traefik middleware for security headers

--- a/linux/playbooks/dnsmasq-setup.yml
+++ b/linux/playbooks/dnsmasq-setup.yml
@@ -1,0 +1,139 @@
+---
+# Installs dnsmasq on the master node to provide wildcard DNS for *.home.lan.
+# After running this playbook, update your router's DHCP settings to hand out
+# the server's IP as DNS Server 1 so all LAN clients resolve *.home.lan automatically.
+#
+# Before running:
+#   cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+#   # edit hosts-local.ini with your real IPs, username, and timezone
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/dnsmasq-setup.yml \
+#     --ask-become-pass
+
+- name: Set up local DNS with dnsmasq
+  hosts: master
+  become: true
+
+  vars:
+    homelab_domain: "home.lan"
+    # Upstream DNS servers — used for all queries except *.home.lan
+    upstream_dns_1: "1.1.1.1"
+    upstream_dns_2: "8.8.8.8"
+
+  tasks:
+
+    # -- 1. Install dnsmasq -----------------------------------------------------
+    - name: Install dnsmasq
+      ansible.builtin.apt:
+        name: dnsmasq
+        state: present
+        update_cache: true
+
+    # -- 2. Disable systemd-resolved to free port 53 ----------------------------
+    # Ubuntu uses systemd-resolved by default, which binds to port 53 and
+    # conflicts with dnsmasq. We disable it and point /etc/resolv.conf to dnsmasq.
+    - name: Stop and disable systemd-resolved
+      ansible.builtin.service:
+        name: systemd-resolved
+        state: stopped
+        enabled: false
+
+    - name: Remove existing /etc/resolv.conf symlink
+      ansible.builtin.file:
+        path: /etc/resolv.conf
+        state: absent
+
+    - name: Create static /etc/resolv.conf pointing to localhost
+      ansible.builtin.copy:
+        content: |
+          # Managed by Ansible — dnsmasq-setup.yml
+          nameserver 127.0.0.1
+        dest: /etc/resolv.conf
+        owner: root
+        group: root
+        mode: '0644'
+
+    # -- 3. Configure dnsmasq ---------------------------------------------------
+    - name: Get server LAN IP
+      ansible.builtin.set_fact:
+        server_ip: "{{ ansible_default_ipv4.address }}"
+
+    - name: Write dnsmasq configuration
+      ansible.builtin.copy:
+        content: |
+          # Managed by Ansible — dnsmasq-setup.yml
+          # Wildcard DNS: all *.{{ homelab_domain }} queries resolve to this server
+          address=/{{ homelab_domain }}/{{ server_ip }}
+
+          # Upstream DNS servers for everything else
+          server={{ upstream_dns_1 }}
+          server={{ upstream_dns_2 }}
+
+          # Only listen on localhost and the LAN interface
+          listen-address=127.0.0.1,{{ server_ip }}
+          bind-interfaces
+
+          # Don't read /etc/resolv.conf for upstream servers (we set them above)
+          no-resolv
+
+          # Cache DNS queries (default 150, increase for a small LAN)
+          cache-size=1000
+
+          # Log DNS queries (useful for debugging, disable later if noisy)
+          log-queries
+          log-facility=/var/log/dnsmasq.log
+        dest: /etc/dnsmasq.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart dnsmasq
+
+    # -- 4. Open UFW port 53 for LAN clients ------------------------------------
+    - name: Allow DNS (UDP) through UFW
+      community.general.ufw:
+        rule: allow
+        port: 53
+        proto: udp
+
+    - name: Allow DNS (TCP) through UFW
+      community.general.ufw:
+        rule: allow
+        port: 53
+        proto: tcp
+
+    # -- 5. Enable and start dnsmasq --------------------------------------------
+    - name: Enable and start dnsmasq
+      ansible.builtin.service:
+        name: dnsmasq
+        state: started
+        enabled: true
+
+    # -- 6. Verify --------------------------------------------------------------
+    - name: Test wildcard DNS resolution
+      ansible.builtin.command: dig +short test.{{ homelab_domain }} @127.0.0.1
+      register: dns_test
+      changed_when: false
+
+    - name: Display DNS test result
+      ansible.builtin.debug:
+        msg: >-
+          DNS test: test.{{ homelab_domain }} resolves to {{ dns_test.stdout | trim }}.
+          {% if dns_test.stdout | trim == server_ip %}
+          Wildcard DNS is working correctly.
+          {% else %}
+          WARNING: Expected {{ server_ip }} but got {{ dns_test.stdout | trim }}. Check dnsmasq configuration.
+          {% endif %}
+
+    - name: Display next steps
+      ansible.builtin.debug:
+        msg: >-
+          dnsmasq is running. Next step: update your router's DHCP settings to
+          set DNS Server 1 to {{ server_ip }} so all LAN clients resolve
+          *.{{ homelab_domain }} automatically. See docs/dns.md for instructions.
+
+  handlers:
+    - name: Restart dnsmasq
+      ansible.builtin.service:
+        name: dnsmasq
+        state: restarted

--- a/traefik/playbooks/traefik-setup.yml
+++ b/traefik/playbooks/traefik-setup.yml
@@ -1,0 +1,107 @@
+---
+# Before running:
+#   cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+#   # edit hosts-local.ini with your real IPs, username, and timezone
+#
+#   ansible-galaxy collection install -r requirements.yml
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini traefik/playbooks/traefik-setup.yml \
+#     --ask-become-pass
+
+- name: Install Traefik via Helm
+  hosts: master
+  become: true
+
+  vars:
+    traefik_chart_version: "36.4.0"   # https://artifacthub.io/packages/helm/traefik/traefik
+    traefik_namespace: "traefik"
+    homelab_domain: "home.lan"         # wildcard domain for local services
+
+  tasks:
+
+    # -- 1. Install prerequisites ------------------------------------------------
+    - name: Install kubernetes Python library (required by kubernetes.core modules)
+      ansible.builtin.apt:
+        name: python3-kubernetes
+        state: present
+        update_cache: true
+
+    - name: Add Traefik Helm repo
+      kubernetes.core.helm_repository:
+        name: traefik
+        repo_url: https://traefik.github.io/charts
+        kubeconfig: /etc/rancher/k3s/k3s.yaml
+
+    # -- 2. Install Traefik via Helm ---------------------------------------------
+    - name: Create traefik namespace
+      kubernetes.core.k8s:
+        name: "{{ traefik_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: present
+        kubeconfig: /etc/rancher/k3s/k3s.yaml
+
+    - name: Install Traefik chart
+      kubernetes.core.helm:
+        name: traefik
+        chart_ref: traefik/traefik
+        chart_version: "{{ traefik_chart_version }}"
+        release_namespace: "{{ traefik_namespace }}"
+        kubeconfig: /etc/rancher/k3s/k3s.yaml
+        atomic: true
+        values:
+          # Use K3s ServiceLB — Traefik gets an external IP from the node
+          service:
+            type: LoadBalancer
+          # Enable the Traefik dashboard (not exposed externally by default)
+          ingressRoute:
+            dashboard:
+              enabled: true
+          # Entrypoints
+          ports:
+            web:
+              port: 8000
+              exposedPort: 80
+              protocol: TCP
+            websecure:
+              port: 8443
+              exposedPort: 443
+              protocol: TCP
+          # Log level
+          logs:
+            general:
+              level: INFO
+      register: traefik_helm_install
+      retries: 3
+      delay: 15
+      until: traefik_helm_install is succeeded
+
+    # -- 3. Wait for Traefik to be ready -----------------------------------------
+    - name: Wait for Traefik deployment to be ready
+      kubernetes.core.k8s_info:
+        kind: Deployment
+        namespace: "{{ traefik_namespace }}"
+        name: traefik
+        kubeconfig: /etc/rancher/k3s/k3s.yaml
+      register: traefik_deploy
+      until: traefik_deploy.resources[0].status.readyReplicas | default(0) >= 1
+      retries: 20
+      delay: 10
+
+    - name: Get Traefik LoadBalancer IP
+      kubernetes.core.k8s_info:
+        kind: Service
+        namespace: "{{ traefik_namespace }}"
+        name: traefik
+        kubeconfig: /etc/rancher/k3s/k3s.yaml
+      register: traefik_svc
+
+    - name: Display Traefik service info
+      ansible.builtin.debug:
+        msg: >-
+          Traefik is running. LoadBalancer IP:
+          {{ traefik_svc.resources[0].status.loadBalancer.ingress[0].ip | default('pending — check kubectl get svc -n traefik') }}.
+          HTTP on port 80, HTTPS on port 443.
+          Dashboard available via: kubectl port-forward -n traefik deploy/traefik 9000:9000
+          then open http://localhost:9000/dashboard/

--- a/traefik/playbooks/traefik-setup.yml
+++ b/traefik/playbooks/traefik-setup.yml
@@ -14,7 +14,7 @@
   become: true
 
   vars:
-    traefik_chart_version: "36.4.0"   # https://artifacthub.io/packages/helm/traefik/traefik
+    traefik_chart_version: "39.0.8"   # https://artifacthub.io/packages/helm/traefik/traefik (appVersion: v3.6.13)
     traefik_namespace: "traefik"
     homelab_domain: "home.lan"         # wildcard domain for local services
 

--- a/traefik/playbooks/traefik-test.yml
+++ b/traefik/playbooks/traefik-test.yml
@@ -1,0 +1,196 @@
+---
+# Deploys a whoami test app with a Traefik IngressRoute to validate that:
+#   1. Traefik routes HTTP traffic correctly
+#   2. Local DNS (*.home.lan) resolves to the server
+#
+# Prerequisites:
+#   - Traefik installed (traefik/playbooks/traefik-setup.yml)
+#   - dnsmasq configured (linux/playbooks/dnsmasq-setup.yml)
+#   - Router DHCP pointing DNS to the server IP
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini traefik/playbooks/traefik-test.yml \
+#     --ask-become-pass
+#
+# To clean up only (skip deploy and validation):
+#   ansible-playbook -i linux/inventory/hosts-local.ini traefik/playbooks/traefik-test.yml \
+#     --ask-become-pass --tags cleanup
+
+- name: Validate Traefik ingress with test deployment
+  hosts: master
+  become: true
+
+  vars:
+    test_namespace: "traefik-test"
+    test_hostname: "whoami.home.lan"
+    kubeconfig: /etc/rancher/k3s/k3s.yaml
+
+  tasks:
+
+    # -- 1. Deploy test app ------------------------------------------------------
+    - name: Create test namespace
+      kubernetes.core.k8s:
+        name: "{{ test_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: present
+        kubeconfig: "{{ kubeconfig }}"
+      tags: [deploy, cleanup]
+
+    - name: Deploy whoami app
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: apps/v1
+          kind: Deployment
+          metadata:
+            name: whoami
+            namespace: "{{ test_namespace }}"
+            labels:
+              app: whoami
+          spec:
+            replicas: 1
+            selector:
+              matchLabels:
+                app: whoami
+            template:
+              metadata:
+                labels:
+                  app: whoami
+              spec:
+                containers:
+                  - name: whoami
+                    image: traefik/whoami:latest
+                    ports:
+                      - containerPort: 80
+      tags: [deploy]
+
+    - name: Create whoami Service
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: v1
+          kind: Service
+          metadata:
+            name: whoami
+            namespace: "{{ test_namespace }}"
+          spec:
+            selector:
+              app: whoami
+            ports:
+              - port: 80
+                targetPort: 80
+      tags: [deploy]
+
+    - name: Create Traefik IngressRoute for whoami
+      kubernetes.core.k8s:
+        kubeconfig: "{{ kubeconfig }}"
+        state: present
+        definition:
+          apiVersion: traefik.io/v1alpha1
+          kind: IngressRoute
+          metadata:
+            name: whoami
+            namespace: "{{ test_namespace }}"
+          spec:
+            entryPoints:
+              - web
+            routes:
+              - match: "Host(`{{ test_hostname }}`)"
+                kind: Rule
+                services:
+                  - name: whoami
+                    port: 80
+      tags: [deploy]
+
+    # -- 2. Wait for deployment to be ready --------------------------------------
+    - name: Wait for whoami deployment to be ready
+      kubernetes.core.k8s_info:
+        kind: Deployment
+        namespace: "{{ test_namespace }}"
+        name: whoami
+        kubeconfig: "{{ kubeconfig }}"
+      register: whoami_deploy
+      until: whoami_deploy.resources[0].status.readyReplicas | default(0) >= 1
+      retries: 15
+      delay: 5
+      tags: [deploy]
+
+    # -- 3. Validate Traefik routing ---------------------------------------------
+    - name: Test Traefik routing via Host header (bypasses DNS)
+      ansible.builtin.uri:
+        url: "http://127.0.0.1"
+        headers:
+          Host: "{{ test_hostname }}"
+        return_content: true
+        status_code: 200
+      register: traefik_test
+      retries: 5
+      delay: 5
+      until: traefik_test.status == 200
+      tags: [deploy]
+
+    - name: Display Traefik routing result
+      ansible.builtin.debug:
+        msg: "Traefik routing is working. whoami responded at {{ test_hostname }}."
+      tags: [deploy]
+
+    # -- 4. Validate DNS resolution ----------------------------------------------
+    - name: Test DNS resolution for {{ test_hostname }}
+      ansible.builtin.command: dig +short {{ test_hostname }} @127.0.0.1
+      register: dns_result
+      changed_when: false
+      tags: [deploy]
+
+    - name: Display DNS resolution result
+      ansible.builtin.debug:
+        msg: >-
+          DNS test: {{ test_hostname }} resolves to {{ dns_result.stdout | trim }}.
+          {% if dns_result.stdout | trim == ansible_default_ipv4.address %}
+          Local DNS is working correctly.
+          {% else %}
+          WARNING: Expected {{ ansible_default_ipv4.address }}. Check dnsmasq configuration.
+          {% endif %}
+      tags: [deploy]
+
+    # -- 5. End-to-end test via hostname -----------------------------------------
+    - name: Test end-to-end via hostname (Traefik + DNS combined)
+      ansible.builtin.uri:
+        url: "http://{{ test_hostname }}"
+        return_content: true
+        status_code: 200
+      register: e2e_test
+      retries: 3
+      delay: 5
+      until: e2e_test.status == 200
+      failed_when: false
+      tags: [deploy]
+
+    - name: Display end-to-end test result
+      ansible.builtin.debug:
+        msg: >-
+          {% if e2e_test.status | default(0) == 200 %}
+          End-to-end test passed. {{ test_hostname }} is reachable via Traefik + DNS.
+          {% else %}
+          End-to-end test failed (status {{ e2e_test.status | default('N/A') }}).
+          Traefik routing works but DNS may not be resolving on this host.
+          Try from a LAN client: curl http://{{ test_hostname }}
+          {% endif %}
+      tags: [deploy]
+
+    # -- 6. Clean up -------------------------------------------------------------
+    - name: Delete test namespace (removes all test resources)
+      kubernetes.core.k8s:
+        name: "{{ test_namespace }}"
+        api_version: v1
+        kind: Namespace
+        state: absent
+        kubeconfig: "{{ kubeconfig }}"
+      tags: [cleanup]
+
+    - name: Display cleanup result
+      ansible.builtin.debug:
+        msg: "Test namespace '{{ test_namespace }}' deleted. All test resources cleaned up."
+      tags: [cleanup]


### PR DESCRIPTION
## Summary

- Add Traefik Helm install playbook (`traefik/playbooks/traefik-setup.yml`) with HTTP/HTTPS entrypoints and K3s ServiceLB
- Add dnsmasq playbook (`linux/playbooks/dnsmasq-setup.yml`) for wildcard `*.home.lan` DNS resolution on the server
- Add Traefik ingress validation playbook (`traefik/playbooks/traefik-test.yml`) that deploys a whoami test app, validates routing + DNS, and cleans up
- Add docs for Traefik setup (`docs/traefik.md`) and local DNS (`docs/dns.md`) including ASUS router DHCP instructions
- Update lint workflow and future-improvements.md to include new playbooks

## Run order

1. `traefik/playbooks/traefik-setup.yml` — install Traefik
2. `linux/playbooks/dnsmasq-setup.yml` — set up local DNS
3. Update router DHCP to point DNS to server IP (see docs/dns.md)
4. `traefik/playbooks/traefik-test.yml` — validate everything works

Closes #26
Closes #27