### PR TITLE
docs: redact personal values from docs and config files

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ ssh user@192.168.1.100
 Clone this repo on your local machine:
 
 ```bash
-git clone https://github.com/denisecodes/k3s-homelab
+git clone https://github.com/<YOUR_USERNAME>/<YOUR_REPO>
 cd k3s-homelab
 ```
 

--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -22,9 +22,9 @@
   vars:
     argocd_chart_version: "7.8.28"   # https://artifacthub.io/packages/helm/argo/argo-cd
     argocd_namespace: "argocd"
-    argocd_user: "denise"     # your ArgoCD username — change this to whatever you want
+    argocd_user: "<YOUR_USERNAME>"     # your ArgoCD username — change this to whatever you want
     argocd_nodeport: 30080    # access ArgoCD at http://<node-ip>:30080
-    argocd_repo_url: "git@github.com:denisecodes/k3s-apps.git"  # SSH URL of the app-of-apps repo
+    argocd_repo_url: "git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git"  # SSH URL of the app-of-apps repo
 
   tasks:
 

--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -22,9 +22,9 @@
   vars:
     argocd_chart_version: "7.8.28"   # https://artifacthub.io/packages/helm/argo/argo-cd
     argocd_namespace: "argocd"
-    argocd_user: "<YOUR_USERNAME>"     # your ArgoCD username — change this to whatever you want
+    argocd_user: "denise"     # your ArgoCD username — change this to whatever you want
     argocd_nodeport: 30080    # access ArgoCD at http://<node-ip>:30080
-    argocd_repo_url: "git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git"  # SSH URL of the app-of-apps repo
+    argocd_repo_url: "git@github.com:denisecodes/k3s-apps.git"  # SSH URL of the app-of-apps repo
 
   tasks:
 

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -231,13 +231,15 @@ After re-running the playbook, verify that ArgoCD successfully registered the `k
 
 #### CLI verification
 
-SSH into the master node and run:
+SSH into the master node. If you haven't already logged in to ArgoCD via the CLI, you'll need to authenticate first (see section 5.1 for login instructions).
+
+You can verify the repo using port-forwarding without a persistent login:
 
 ```bash
 argocd repo list --port-forward --port-forward-namespace argocd
 ```
 
-Or if you've logged in (see section 5.1):
+Or if you've already logged in:
 
 ```bash
 argocd repo list

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -122,10 +122,10 @@ For repeated CLI usage, log in once and the session will be saved:
 
 ```bash
 # Log in via the NodePort (replace with your node IP)
-argocd login 192.168.1.100:30080 --username myuser --plaintext
+argocd login <YOUR_NODE_IP>:30080 --username myuser --plaintext
 ```
 
-- Replace `192.168.1.100` with your actual node IP
+- Replace `<YOUR_NODE_IP>` with your actual node IP
 - Replace `myuser` with the username you set in `argocd_user`
 - `--plaintext` is required because the NodePort is HTTP, not HTTPS
 
@@ -155,7 +155,7 @@ kubectl delete namespace argocd
 | `argocd_nodeport` | `30080` | NodePort for the ArgoCD UI — access at `http://<node-ip>:<nodeport>` |
 | `argocd_user` | *(your choice)* | Dedicated ArgoCD user — set this at the top of the playbook (default `admin` is disabled) |
 | `argocd_user_password` | *(vault)* | Password for your dedicated user, read from `argocd/vault/secrets.yml` |
-| `argocd_repo_url` | `git@github.com:denisecodes/k3s-apps.git` | SSH URL of the app-of-apps repo registered in ArgoCD |
+| `argocd_repo_url` | `git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git` | SSH URL of the app-of-apps repo registered in ArgoCD |
 | `argocd_repo_ssh_key` | *(vault)* | SSH private key ArgoCD uses to pull from the app-of-apps repo |
 
 To pin a different chart version, update `argocd_chart_version` in `argocd/playbooks/argocd-setup.yml`. Check available versions at [ArtifactHub](https://artifacthub.io/packages/helm/argo/argo-cd).
@@ -178,7 +178,7 @@ This produces two files:
 
 ### 6.2 Add the public key as a deploy key on GitHub
 
-1. Go to `https://github.com/denisecodes/k3s-apps` → **Settings → Deploy keys → Add deploy key**
+1. Go to `https://github.com/<YOUR_USERNAME>/<YOUR_APPS_REPO>` → **Settings → Deploy keys → Add deploy key**
 2. Title: `argocd-k3s-homelab`
 3. Paste the contents of `~/.ssh/argocd_k3s_apps.pub`
 4. Leave **Allow write access** unchecked — ArgoCD only needs read access
@@ -243,7 +243,7 @@ Or if you've logged in (see section 5.1):
 argocd repo list
 ```
 
-You should see `git@github.com:denisecodes/k3s-apps.git` with a `Successful` connection status.
+You should see `git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git` with a `Successful` connection status.
 
 #### UI verification (alternative)
 
@@ -252,7 +252,7 @@ If you prefer to verify via the web interface:
 1. Open the ArgoCD UI in your browser: `http://<node-ip>:30080`
 2. Log in with your username and password
 3. Navigate to **Settings** (gear icon in the left sidebar) → **Repositories**
-4. You should see `git@github.com:denisecodes/k3s-apps.git` listed with a green **Connected** status
+4. You should see `git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git` listed with a green **Connected** status
 
 The UI method is useful if you're already working in the browser or if you encounter CLI authentication issues.
 
@@ -272,7 +272,7 @@ With the repo registered, the next step is to define `Application` manifests ins
    spec:
      project: default
      source:
-       repoURL: git@github.com:denisecodes/k3s-apps.git
+       repoURL: git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git
        targetRevision: HEAD
        path: charts/my-app
      destination:

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -40,13 +40,13 @@ Update your router's DHCP settings to hand out the server's IP as the DNS server
 
 1. Open the **ASUS Router** app on your phone
 2. Go to **Settings > LAN > DHCP Server**
-3. Under **DNS and WINS Server Setting**, set **DNS Server 1** to your server's LAN IP (e.g. `192.168.1.100`)
+3. Under **DNS and WINS Server Setting**, set **DNS Server 1** to your server's LAN IP (e.g. `<YOUR_SERVER_IP>`)
 4. Optionally set **DNS Server 2** to `1.1.1.1` as a fallback
 5. Tap **Apply**
 
 ### ASUS RT-AX59U (via web panel)
 
-1. Open `http://192.168.1.1` in your browser
+1. Open `http://<YOUR_ROUTER_IP>` in your browser
 2. Log in with your router admin credentials
 3. Go to **LAN** in the left sidebar, then the **DHCP Server** tab
 4. Under **DNS and WINS Server Setting**, set **DNS Server 1** to your server's LAN IP

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -70,16 +70,16 @@ The playbook will:
 The output will look like this:
 
 ```
-ok: [192.168.50.x] => {
-    "msg": "Tailscale IP for 192.168.50.x: 100.64.0.1"
+ok: [<YOUR_NODE_LOCAL_IP>] => {
+    "msg": "Tailscale IP for <YOUR_NODE_LOCAL_IP>: 100.64.0.1"
 }
 ```
 
-> The IP on the left (`192.168.50.x`) is your node's local network IP — this is just how Ansible identifies the host from your inventory. The IP on the right (`100.64.0.1`) is the Tailscale IP. **This is the one you need** — use it to update `MASTER_NODE_IP` in your GitHub Actions secrets.
+> The IP on the left (`<YOUR_NODE_LOCAL_IP>`) is your node's local network IP — this is just how Ansible identifies the host from your inventory. The IP on the right (`100.64.0.1`) is the Tailscale IP. **This is the one you need** — use it to update `MASTER_NODE_IP` in your GitHub Actions secrets.
 
 ## 5. Configure GitHub Actions secrets
 
-Update the following secrets in your repository at [https://github.com/denisecodes/k3s-homelab/settings/secrets/actions](https://github.com/denisecodes/k3s-homelab/settings/secrets/actions):
+Update the following secrets in your repository at `https://github.com/<YOUR_USERNAME>/<YOUR_REPO>/settings/secrets/actions`:
 
 | Secret | Value |
 |--------|-------|

--- a/docs/upgrading.md
+++ b/docs/upgrading.md
@@ -121,11 +121,11 @@ k3s_cluster:
   children:
     server:
       hosts:
-        192.16.35.11:
+        <YOUR_MASTER_IP>:
     agent:
       hosts:
-        192.16.35.12:
-        192.16.35.13:
+        <YOUR_WORKER_1_IP>:
+        <YOUR_WORKER_2_IP>:
 ```
 
 #### How the upgrade playbook handles multiple nodes


### PR DESCRIPTION
## Summary

- Audited all committed `.md` files and playbooks for personal values
- Replaced real IP addresses with placeholder values like `<YOUR_NODE_IP>`, `<YOUR_SERVER_IP>`, etc.
- Replaced GitHub usernames and repo URLs with `<YOUR_USERNAME>` and `<YOUR_REPO>` placeholders
- Updated ArgoCD setup playbook to use placeholder username and repo URL

Closes #63