### PR TITLE
feat: add argocd-apps application to setup playbook

### DIFF
--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -218,3 +218,28 @@
             type: git
             url: "{{ argocd_repo_url }}"
             sshPrivateKey: "{{ argocd_repo_ssh_key }}"
+
+    # ── 7. Deploy argocd-apps Application ─────────────────────────────
+    - name: Deploy argocd-apps Application (watches k3s-apps repo)
+      kubernetes.core.k8s:
+        state: present
+        kubeconfig: /etc/rancher/k3s/k3s.yaml
+        definition:
+          apiVersion: argoproj.io/v1alpha1
+          kind: Application
+          metadata:
+            name: argocd-apps
+            namespace: "{{ argocd_namespace }}"
+          spec:
+            project: default
+            source:
+              repoURL: "{{ argocd_repo_url }}"
+              targetRevision: main
+              path: apps
+            destination:
+              server: https://kubernetes.default.svc
+              namespace: "{{ argocd_namespace }}"
+            syncPolicy:
+              automated:
+                prune: true
+                selfHeal: true

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -8,6 +8,8 @@ ArgoCD is installed via Helm using the official `argo/argo-cd` chart. The playbo
 - Deploys ArgoCD into the `argocd` namespace
 - Installs the `argocd` CLI, version-matched to the deployed chart
 - Creates a dedicated user (configured via `argocd_user`) and disables the default `admin` account
+- Registers the k3s-apps repository via SSH deploy key
+- Deploys the `argocd-apps` Application that watches the k3s-apps repository for application manifests
 
 ## Prerequisites
 
@@ -155,8 +157,8 @@ kubectl delete namespace argocd
 | `argocd_nodeport` | `30080` | NodePort for the ArgoCD UI — access at `http://<node-ip>:<nodeport>` |
 | `argocd_user` | *(your choice)* | Dedicated ArgoCD user — set this at the top of the playbook (default `admin` is disabled) |
 | `argocd_user_password` | *(vault)* | Password for your dedicated user, read from `argocd/vault/secrets.yml` |
-| `argocd_repo_url` | `git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git` | SSH URL of the app-of-apps repo registered in ArgoCD |
-| `argocd_repo_ssh_key` | *(vault)* | SSH private key ArgoCD uses to pull from the app-of-apps repo |
+| `argocd_repo_url` | `git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git` | SSH URL of the k3s-apps repo registered in ArgoCD |
+| `argocd_repo_ssh_key` | *(vault)* | SSH private key ArgoCD uses to pull from the k3s-apps repo |
 
 To pin a different chart version, update `argocd_chart_version` in `argocd/playbooks/argocd-setup.yml`. Check available versions at [ArtifactHub](https://artifacthub.io/packages/helm/argo/argo-cd).
 
@@ -262,9 +264,11 @@ The UI method is useful if you're already working in the browser or if you encou
 
 ### GitOps app deployment via ArgoCD
 
-With the repo registered, the next step is to define `Application` manifests inside `k3s-apps` and have ArgoCD sync them automatically:
+With the playbook complete, ArgoCD is now watching the `k3s-apps` repository. The `argocd-apps` Application is automatically deployed and monitors the `apps/` directory for new application manifests.
 
-1. **Create an `Application` manifest** in the `k3s-apps` repo — define what to deploy and where:
+To deploy a new application:
+
+1. **Create an `Application` manifest** in the `k3s-apps/apps/` directory:
    ```yaml
    apiVersion: argoproj.io/v1alpha1
    kind: Application
@@ -274,9 +278,9 @@ With the repo registered, the next step is to define `Application` manifests ins
    spec:
      project: default
      source:
-       repoURL: git@github.com:<YOUR_USERNAME>/<YOUR_APPS_REPO>.git
-       targetRevision: HEAD
-       path: charts/my-app
+       repoURL: https://my-helm-repo.example.com
+       targetRevision: 1.0.0
+       chart: my-app
      destination:
        server: https://kubernetes.default.svc
        namespace: my-app
@@ -286,4 +290,4 @@ With the repo registered, the next step is to define `Application` manifests ins
          selfHeal: true
    ```
 
-2. **Automate with Ansible** — add `kubernetes.core.k8s` tasks to `argocd-setup.yml` to apply `Application` manifests, so the full cluster state is declared in code and reproduced by running the playbook.
+2. **Commit and push** to the k3s-apps repository — ArgoCD will automatically detect and sync the new application.


### PR DESCRIPTION
## Summary
- Add argocd-apps Application deployment to ArgoCD setup playbook
- Application watches k3s-apps repository apps/ directory for application manifests
- Update documentation to reflect automatic argocd-apps deployment
- Remove need for manual app-of-apps creation after ArgoCD installation

## Changes
- Updated `argocd/playbooks/argocd-setup.yml` to deploy argocd-apps Application after k3s-apps repo registration
- Updated `docs/argocd.md` to document the automatic deployment and new GitOps workflow

## Testing
✅ Playbook tested successfully - argocd-apps Application deployed correctly

Closes #66