### PR TITLE
feat: add UFW rules for Traefik (80/443) and Longhorn UI (8080)

### DIFF
--- a/linux/playbooks/server-setup.yml
+++ b/linux/playbooks/server-setup.yml
@@ -50,6 +50,21 @@
         proto: tcp
       when: "'master' in group_names"
 
+    - name: Allow HTTP/HTTPS for Traefik ingress
+      community.general.ufw:
+        rule: allow
+        port: "{{ item }}"
+        proto: tcp
+      loop:
+        - 80
+        - 443
+
+    - name: Allow Longhorn UI
+      community.general.ufw:
+        rule: allow
+        port: 8080
+        proto: tcp
+
     - name: Disable root SSH login
       ansible.builtin.lineinfile:
         path: /etc/ssh/sshd_config


### PR DESCRIPTION
## Summary

- **Added UFW firewall rules** to `linux/playbooks/server-setup.yml`:
  - Ports 80/443 for Traefik ingress (HTTP/HTTPS)
  - Port 8080 for Longhorn UI

### Why These Rules

- **Traefik (80/443)**: Required for ingress controller to handle HTTP/HTTPS traffic to services
- **Longhorn UI (8080)**: Allows access to Longhorn storage management dashboard

### Changes Made

Added two UFW rule tasks after the K3s API rule in server-setup.yml:

```yaml
- name: Allow HTTP/HTTPS for Traefik ingress
  community.general.ufw:
    rule: allow
    port: "{{ item }}"
    proto: tcp
  loop:
    - 80
    - 443

- name: Allow Longhorn UI
  community.general.ufw:
    rule: allow
    port: 8080
    proto: tcp
```

Related PR in k3s-apps: https://github.com/denisecodes/k3s-apps/pull/3 (Longhorn deployment)

Closes #25