### PR TITLE
fix: enable directory recursion for argocd-apps to support organized app structure

### DIFF
--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -236,6 +236,8 @@
               repoURL: "{{ argocd_repo_url }}"
               targetRevision: main
               path: apps
+              directory:
+                recurse: true
             destination:
               server: https://kubernetes.default.svc
               namespace: "{{ argocd_namespace }}"


### PR DESCRIPTION
## Summary

Enables `directory.recurse: true` in the `argocd-apps` Application definition within the ArgoCD setup playbook.

## Why This Change

After reorganizing the k3s-apps repository to use subdirectories for each app (e.g., `apps/traefik/`, `apps/sealed-secrets/`, `apps/longhorn/`), ArgoCD was unable to discover Application manifests in subdirectories.

## Changes Made

Updated `argocd/playbooks/argocd-setup.yml` to include:

```yaml
source:
  repoURL: "{{ argocd_repo_url }}"
  targetRevision: main
  path: apps
  directory:
    recurse: true  # ← Added this
```

## Impact

- **Enables ArgoCD to recursively scan** the `apps/` directory for Application manifests
- **Supports the new organized structure** in k3s-apps where each app has its own subdirectory
- **Future-proof** for adding more apps with their own directories

## Related

- Related to k3s-apps PR: https://github.com/denisecodes/k3s-apps/pull/3
- Addresses issue discovered during deployment of denisecodes/k3s-homelab#25

## Testing

After merging, when running the ArgoCD setup playbook again (or when recreating the `argocd-apps` Application), it will automatically discover apps in subdirectories.

To verify manually:
```bash
kubectl get application argocd-apps -n argocd -o jsonpath='{.spec.source.directory.recurse}'
# Should output: true
```