### PR TITLE
Configure local DNS resolution for ArgoCD and Longhorn via Traefik

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,6 +259,24 @@ NAME         STATUS   ROLES                  AGE   VERSION
 home-k8s     Ready    control-plane,master   10m   v1.33.10+k3s1
 ```
 
+## Accessing services
+
+### Via friendly hostnames (recommended)
+
+Once you've configured local DNS (see [docs/dns.md](docs/dns.md)), services with Traefik IngressRoutes can be accessed via friendly hostnames:
+
+- **ArgoCD**: http://argocd.home.lan
+- **Longhorn**: http://longhorn.home.lan
+
+New services automatically get DNS resolution when you create a Traefik IngressRoute. See `ingress/README.md` for examples.
+
+### Via NodePort (fallback)
+
+Services are also accessible via NodePort using `http://<node-ip>:<port>`:
+
+- **ArgoCD**: http://192.168.50.113:30080
+- **Longhorn**: Check the service port with `kubectl get svc -n longhorn-system`
+
 ## Upgrading K3s
 
 For full details on the upgrade process, including the automated GitHub Actions workflow and manual steps, see [docs/upgrading.md](docs/upgrading.md).

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -73,7 +73,21 @@ ansible-playbook -i linux/inventory/hosts.ini argocd/playbooks/argocd-setup.yml 
 
 ## 4. Access the ArgoCD UI
 
-ArgoCD is exposed via **NodePort** on port `30080`. Open your browser and navigate to:
+### Option 1: Via hostname (recommended)
+
+If you've configured local DNS (see [DNS setup](dns.md)), you can access ArgoCD at:
+
+```
+http://argocd.home.lan
+```
+
+This requires:
+- dnsmasq configured to resolve `*.home.lan` to Traefik's LoadBalancer IP
+- Traefik IngressRoute deployed (see `apps/argocd/ingressroute.yaml` in k3s-apps repo)
+
+### Option 2: Via NodePort (fallback)
+
+ArgoCD is also exposed via **NodePort** on port `30080`. Open your browser and navigate to:
 
 ```
 http://<node-ip>:30080
@@ -84,6 +98,8 @@ For example, if your node IP is `192.168.1.100`:
 ```
 http://192.168.1.100:30080
 ```
+
+### Login credentials
 
 Log in with:
 

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -6,11 +6,12 @@ This document covers how to set up local DNS so homelab services are reachable b
 
 [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) runs on the homelab server and provides wildcard DNS resolution:
 
-- Any `*.home.lan` query resolves to the server's LAN IP
+- Any `*.home.lan` query resolves to the **Traefik LoadBalancer IP** (192.168.50.113)
+- Traefik routes traffic to the appropriate service based on the hostname
 - All other DNS queries are forwarded to upstream resolvers (Cloudflare `1.1.1.1` and Google `8.8.8.8`)
 - The router's DHCP hands out the server's IP as the DNS server for all LAN clients
 
-This means new apps automatically get DNS — no per-app DNS entries needed.
+This means new apps automatically get DNS — no per-app DNS entries needed. Simply create a Traefik IngressRoute with the desired hostname.
 
 ## Prerequisites
 
@@ -74,10 +75,21 @@ From any device on your LAN:
 nslookup whoami.home.lan
 ```
 
-This should return your server's LAN IP. If it doesn't, check that:
+This should return the Traefik LoadBalancer IP (192.168.50.113). If it doesn't, check that:
 - dnsmasq is running on the server: `sudo systemctl status dnsmasq`
 - The router DHCP is handing out the correct DNS: check your device's DNS settings
 - UFW is allowing port 53: `sudo ufw status`
+
+## 5. Access services via hostname
+
+Services with Traefik IngressRoutes can be accessed via their configured hostnames:
+
+- **ArgoCD**: http://argocd.home.lan
+- **Longhorn**: http://longhorn.home.lan
+
+To add a new service, create a Traefik IngressRoute in the k3s-apps repository. See examples in:
+- `apps/argocd/ingressroute.yaml`
+- `apps/longhorn/ingressroute.yaml`
 
 ## Configuration
 
@@ -86,6 +98,7 @@ Key variables in `linux/playbooks/dnsmasq-setup.yml`:
 | Variable | Default | Description |
 |---|---|---|
 | `homelab_domain` | `home.lan` | Wildcard domain for local services |
+| `traefik_ip` | `192.168.50.113` | Traefik LoadBalancer IP (all `*.home.lan` traffic routes here) |
 | `upstream_dns_1` | `1.1.1.1` | Primary upstream DNS (Cloudflare) |
 | `upstream_dns_2` | `8.8.8.8` | Secondary upstream DNS (Google) |
 

--- a/linux/playbooks/dnsmasq-setup.yml
+++ b/linux/playbooks/dnsmasq-setup.yml
@@ -17,6 +17,8 @@
 
   vars:
     homelab_domain: "home.lan"
+    # Traefik LoadBalancer IP — all *.home.lan traffic routes through Traefik
+    traefik_ip: "192.168.50.113"
     # Upstream DNS servers — used for all queries except *.home.lan
     upstream_dns_1: "1.1.1.1"
     upstream_dns_2: "8.8.8.8"
@@ -63,8 +65,8 @@
       ansible.builtin.copy:
         content: |
           # Managed by Ansible — dnsmasq-setup.yml
-          # Wildcard DNS: all *.{{ homelab_domain }} queries resolve to this server
-          address=/{{ homelab_domain }}/{{ server_ip }}
+          # Wildcard DNS: all *.{{ homelab_domain }} queries resolve to Traefik LoadBalancer
+          address=/{{ homelab_domain }}/{{ traefik_ip }}
 
           # Upstream DNS servers for everything else
           server={{ upstream_dns_1 }}
@@ -119,10 +121,10 @@
       ansible.builtin.debug:
         msg: >-
           DNS test: test.{{ homelab_domain }} resolves to {{ dns_test.stdout | trim }}.
-          {% if dns_test.stdout | trim == server_ip %}
-          Wildcard DNS is working correctly.
+          {% if dns_test.stdout | trim == traefik_ip %}
+          Wildcard DNS is working correctly - resolving to Traefik LoadBalancer.
           {% else %}
-          WARNING: Expected {{ server_ip }} but got {{ dns_test.stdout | trim }}. Check dnsmasq configuration.
+          WARNING: Expected {{ traefik_ip }} but got {{ dns_test.stdout | trim }}. Check dnsmasq configuration.
           {% endif %}
 
     - name: Display next steps


### PR DESCRIPTION
## Summary
- Updated dnsmasq playbook to resolve `*.home.lan` to Traefik LoadBalancer IP (192.168.50.113)
- Updated documentation for DNS, ArgoCD, and main README to reflect hostname-based access
- Services now accessible via friendly hostnames instead of IP:port combinations

## Changes
- **dnsmasq configuration**: Wildcard DNS now resolves to Traefik LoadBalancer instead of server IP
- **Documentation updates**: Added hostname access methods and examples
- **User experience**: Cleaner service access (e.g., http://argocd.home.lan instead of http://192.168.50.113:30080)

## Testing
- ✅ dnsmasq resolves `*.home.lan` to 192.168.50.113
- ✅ ArgoCD accessible at http://argocd.home.lan
- ✅ Longhorn accessible at http://longhorn.home.lan
- ✅ NodePort access still works as fallback

Closes #74