### PR TITLE
fix: replace real IP addresses with placeholders and require variable from inventory

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ New services automatically get DNS resolution when you create a Traefik IngressR
 
 Services are also accessible via NodePort using `http://<node-ip>:<port>`:
 
-- **ArgoCD**: http://192.168.50.113:30080
+- **ArgoCD**: http://<YOUR_NODE_IP>:30080
 - **Longhorn**: Check the service port with `kubectl get svc -n longhorn-system`
 
 ## Upgrading K3s

--- a/docs/dns.md
+++ b/docs/dns.md
@@ -6,7 +6,7 @@ This document covers how to set up local DNS so homelab services are reachable b
 
 [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) runs on the homelab server and provides wildcard DNS resolution:
 
-- Any `*.home.lan` query resolves to the **Traefik LoadBalancer IP** (192.168.50.113)
+- Any `*.home.lan` query resolves to the **Traefik LoadBalancer IP** (`<TRAEFIK_LOADBALANCER_IP>`)
 - Traefik routes traffic to the appropriate service based on the hostname
 - All other DNS queries are forwarded to upstream resolvers (Cloudflare `1.1.1.1` and Google `8.8.8.8`)
 - The router's DHCP hands out the server's IP as the DNS server for all LAN clients
@@ -75,7 +75,7 @@ From any device on your LAN:
 nslookup whoami.home.lan
 ```
 
-This should return the Traefik LoadBalancer IP (192.168.50.113). If it doesn't, check that:
+This should return the Traefik LoadBalancer IP (`<TRAEFIK_LOADBALANCER_IP>`). If it doesn't, check that:
 - dnsmasq is running on the server: `sudo systemctl status dnsmasq`
 - The router DHCP is handing out the correct DNS: check your device's DNS settings
 - UFW is allowing port 53: `sudo ufw status`
@@ -98,7 +98,7 @@ Key variables in `linux/playbooks/dnsmasq-setup.yml`:
 | Variable | Default | Description |
 |---|---|---|
 | `homelab_domain` | `home.lan` | Wildcard domain for local services |
-| `traefik_ip` | `192.168.50.113` | Traefik LoadBalancer IP (all `*.home.lan` traffic routes here) |
+| `traefik_ip` | `<TRAEFIK_LOADBALANCER_IP>` | Traefik LoadBalancer IP (all `*.home.lan` traffic routes here) |
 | `upstream_dns_1` | `1.1.1.1` | Primary upstream DNS (Cloudflare) |
 | `upstream_dns_2` | `8.8.8.8` | Secondary upstream DNS (Google) |
 

--- a/linux/inventory/hosts.ini
+++ b/linux/inventory/hosts.ini
@@ -14,3 +14,5 @@ workers
 ansible_user=<YOUR_UBUNTU_USERNAME>
 ansible_ssh_private_key_file=~/.ssh/id_ed25519
 timezone=<YOUR_TIMEZONE>
+# Required for dnsmasq playbook - find with: kubectl get svc -n traefik
+traefik_loadbalancer_ip=<TRAEFIK_LOADBALANCER_IP>

--- a/linux/playbooks/dnsmasq-setup.yml
+++ b/linux/playbooks/dnsmasq-setup.yml
@@ -4,8 +4,9 @@
 # the server's IP as DNS Server 1 so all LAN clients resolve *.home.lan automatically.
 #
 # Before running:
-#   cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
-#   # edit hosts-local.ini with your real IPs, username, and timezone
+#   1. cp linux/inventory/hosts.ini linux/inventory/hosts-local.ini
+#   2. Edit hosts-local.ini with your real IPs, username, and timezone
+#   3. Set traefik_loadbalancer_ip in hosts-local.ini under [homelab:vars]
 #
 # Run with:
 #   ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/dnsmasq-setup.yml \
@@ -17,15 +18,31 @@
 
   vars:
     homelab_domain: "home.lan"
-    # Traefik LoadBalancer IP — all *.home.lan traffic routes through Traefik
-    traefik_ip: "192.168.50.113"
     # Upstream DNS servers — used for all queries except *.home.lan
     upstream_dns_1: "1.1.1.1"
     upstream_dns_2: "8.8.8.8"
 
   tasks:
 
-    # -- 1. Install dnsmasq -----------------------------------------------------
+    # -- 1. Verify required variables are set -----------------------------------
+    - name: Check that traefik_loadbalancer_ip is defined
+      ansible.builtin.assert:
+        that:
+          - traefik_loadbalancer_ip is defined
+          - traefik_loadbalancer_ip != ""
+        fail_msg: |
+          ERROR: traefik_loadbalancer_ip is not set!
+          
+          Please set it in your inventory file (linux/inventory/hosts-local.ini):
+          
+          [homelab:vars]
+          traefik_loadbalancer_ip=<YOUR_TRAEFIK_IP>
+          
+          This should be the external IP of your Traefik LoadBalancer service.
+          Find it with: kubectl get svc -n traefik
+        success_msg: "traefik_loadbalancer_ip is set to {{ traefik_loadbalancer_ip }}"
+
+    # -- 2. Install dnsmasq -----------------------------------------------------
     - name: Install dnsmasq
       ansible.builtin.apt:
         name: dnsmasq
@@ -66,7 +83,7 @@
         content: |
           # Managed by Ansible — dnsmasq-setup.yml
           # Wildcard DNS: all *.{{ homelab_domain }} queries resolve to Traefik LoadBalancer
-          address=/{{ homelab_domain }}/{{ traefik_ip }}
+          address=/{{ homelab_domain }}/{{ traefik_loadbalancer_ip }}
 
           # Upstream DNS servers for everything else
           server={{ upstream_dns_1 }}
@@ -121,10 +138,10 @@
       ansible.builtin.debug:
         msg: >-
           DNS test: test.{{ homelab_domain }} resolves to {{ dns_test.stdout | trim }}.
-          {% if dns_test.stdout | trim == traefik_ip %}
+          {% if dns_test.stdout | trim == traefik_loadbalancer_ip %}
           Wildcard DNS is working correctly - resolving to Traefik LoadBalancer.
           {% else %}
-          WARNING: Expected {{ traefik_ip }} but got {{ dns_test.stdout | trim }}. Check dnsmasq configuration.
+          WARNING: Expected {{ traefik_loadbalancer_ip }} but got {{ dns_test.stdout | trim }}. Check dnsmasq configuration.
           {% endif %}
 
     - name: Display next steps


### PR DESCRIPTION
## Summary
- Replaces all real IP addresses with placeholders in documentation and playbooks
- Updates dnsmasq playbook to require `traefik_loadbalancer_ip` from inventory file
- Adds validation that fails with helpful error if variable not set
- Prevents accidental commit of real IP addresses while maintaining ease of use

## Security Fix
Real IP address (192.168.50.113) was committed to the repository in multiple places. This PR removes all instances and implements a safer pattern.

## Changes
**Documentation:**
- `docs/dns.md`: Replaced `192.168.50.113` with `<TRAEFIK_LOADBALANCER_IP>` placeholder (3 instances)
- `README.md`: Replaced `192.168.50.113:30080` with `<YOUR_NODE_IP>:30080`

**Playbooks:**
- `linux/playbooks/dnsmasq-setup.yml`: 
  - Requires `traefik_loadbalancer_ip` variable from inventory
  - Adds validation task that fails with helpful message if not set
  - No hardcoded IP in playbook

**Inventory:**
- `linux/inventory/hosts.ini`: Added `traefik_loadbalancer_ip` variable with placeholder
- Users set real IP in their gitignored `hosts-local.ini` file

## How It Works
Users must set their real Traefik LoadBalancer IP in `linux/inventory/hosts-local.ini`:
```ini
[homelab:vars]
traefik_loadbalancer_ip=<YOUR_ACTUAL_IP>
```

The playbook will fail gracefully with instructions if the variable is not set, preventing accidents.

Closes #77