### PR TITLE
chore: Update DNS domain from home.lan to denise.home

### DIFF
--- a/docs/dns.md
+++ b/docs/dns.md
@@ -6,7 +6,7 @@ This document covers how to set up local DNS so homelab services are reachable b
 
 [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) runs on the homelab server and provides wildcard DNS resolution:
 
-- Any `*.home.lan` query resolves to the **Traefik LoadBalancer IP** (`<TRAEFIK_LOADBALANCER_IP>`)
+- Any `*.denise.home` query resolves to the **Traefik LoadBalancer IP** (`<TRAEFIK_LOADBALANCER_IP>`)
 - Traefik routes traffic to the appropriate service based on the hostname
 - All other DNS queries are forwarded to upstream resolvers (Cloudflare `1.1.1.1` and Google `8.8.8.8`)
 - The router's DHCP hands out the server's IP as the DNS server for all LAN clients
@@ -28,7 +28,7 @@ ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/dnsmasq-setu
 The playbook will:
 - Install dnsmasq
 - Disable systemd-resolved (frees port 53)
-- Configure wildcard DNS for `*.home.lan`
+- Configure wildcard DNS for `*.denise.home`
 - Set upstream DNS forwarders (Cloudflare + Google)
 - Open UFW ports 53/tcp and 53/udp
 - Verify DNS resolution is working
@@ -72,7 +72,7 @@ After updating the router, devices need to renew their DHCP lease to pick up the
 From any device on your LAN:
 
 ```bash
-nslookup whoami.home.lan
+nslookup whoami.denise.home
 ```
 
 This should return the Traefik LoadBalancer IP (`<TRAEFIK_LOADBALANCER_IP>`). If it doesn't, check that:
@@ -84,12 +84,11 @@ This should return the Traefik LoadBalancer IP (`<TRAEFIK_LOADBALANCER_IP>`). If
 
 Services with Traefik IngressRoutes can be accessed via their configured hostnames:
 
-- **ArgoCD**: http://argocd.home.lan
-- **Longhorn**: http://longhorn.home.lan
+- **ArgoCD**: http://argocd.denise.home
+- **Longhorn**: http://longhorn.denise.home
+- **Traefik Dashboard**: http://traefik.denise.home
 
-To add a new service, create a Traefik IngressRoute in the k3s-apps repository. See examples in:
-- `apps/argocd/ingressroute.yaml`
-- `apps/longhorn/ingressroute.yaml`
+To add a new service, create a Traefik IngressRoute in the k3s-apps repository. See examples in `apps/traefik/ingressroutes/` or the [IngressRoutes README](https://github.com/denisecodes/k3s-apps/blob/main/apps/traefik/ingressroutes/README.md).
 
 ## Configuration
 
@@ -97,8 +96,8 @@ Key variables in `linux/playbooks/dnsmasq-setup.yml`:
 
 | Variable | Default | Description |
 |---|---|---|
-| `homelab_domain` | `home.lan` | Wildcard domain for local services |
-| `traefik_ip` | `<TRAEFIK_LOADBALANCER_IP>` | Traefik LoadBalancer IP (all `*.home.lan` traffic routes here) |
+| `homelab_domain` | `denise.home` | Wildcard domain for local services |
+| `traefik_ip` | `<TRAEFIK_LOADBALANCER_IP>` | Traefik LoadBalancer IP (all `*.denise.home` traffic routes here) |
 | `upstream_dns_1` | `1.1.1.1` | Primary upstream DNS (Cloudflare) |
 | `upstream_dns_2` | `8.8.8.8` | Secondary upstream DNS (Google) |
 

--- a/docs/traefik.md
+++ b/docs/traefik.md
@@ -58,10 +58,10 @@ ansible-playbook -i linux/inventory/hosts-local.ini traefik/playbooks/traefik-te
   --ask-become-pass
 ```
 
-This deploys a `whoami` test app with a Traefik IngressRoute at `whoami.home.lan`, validates that:
+This deploys a `whoami` test app with a Traefik IngressRoute at `whoami.denise.home`, validates that:
 
 1. Traefik routes HTTP traffic to the app
-2. DNS resolves `whoami.home.lan` to the server IP
+2. DNS resolves `whoami.denise.home` to the server IP
 3. End-to-end request via hostname works
 
 The playbook automatically cleans up the test resources when done.
@@ -81,7 +81,7 @@ Key variables in `traefik/playbooks/traefik-setup.yml`:
 |---|---|---|
 | `traefik_chart_version` | `36.4.0` | Traefik Helm chart version |
 | `traefik_namespace` | `traefik` | Kubernetes namespace |
-| `homelab_domain` | `home.lan` | Local domain for services |
+| `homelab_domain` | `denise.home` | Local domain for services |
 
 ## Uninstalling Traefik
 

--- a/linux/playbooks/dnsmasq-setup.yml
+++ b/linux/playbooks/dnsmasq-setup.yml
@@ -17,8 +17,8 @@
   become: true
 
   vars:
-    homelab_domain: "home.lan"
-    # Upstream DNS servers — used for all queries except *.home.lan
+    homelab_domain: "denise.home"
+    # Upstream DNS servers — used for all queries except *.denise.home
     upstream_dns_1: "1.1.1.1"
     upstream_dns_2: "8.8.8.8"
 

--- a/traefik/playbooks/traefik-setup.yml
+++ b/traefik/playbooks/traefik-setup.yml
@@ -16,7 +16,7 @@
   vars:
     traefik_chart_version: "39.0.8"   # https://artifacthub.io/packages/helm/traefik/traefik (appVersion: v3.6.13)
     traefik_namespace: "traefik"
-    homelab_domain: "home.lan"         # wildcard domain for local services
+    homelab_domain: "denise.home"      # wildcard domain for local services
 
   tasks:
 

--- a/traefik/playbooks/traefik-test.yml
+++ b/traefik/playbooks/traefik-test.yml
@@ -1,7 +1,7 @@
 ---
 # Deploys a whoami test app with a Traefik IngressRoute to validate that:
 #   1. Traefik routes HTTP traffic correctly
-#   2. Local DNS (*.home.lan) resolves to the server
+#   2. Local DNS (*.denise.home) resolves to the server
 #
 # Prerequisites:
 #   - Traefik installed (traefik/playbooks/traefik-setup.yml)
@@ -22,7 +22,7 @@
 
   vars:
     test_namespace: "traefik-test"
-    test_hostname: "whoami.home.lan"
+    test_hostname: "whoami.denise.home"
     kubeconfig: /etc/rancher/k3s/k3s.yaml
 
   tasks:


### PR DESCRIPTION
## Summary

- Update DNS domain from `home.lan` to `denise.home` for a more personalized homelab domain
- Update dnsmasq playbook to serve `*.denise.home` wildcard domain
- Update traefik-test playbook to test with new domain
- Update all documentation to reflect new domain
- Update service URLs (ArgoCD, Longhorn, Traefik Dashboard)

## Testing Completed

✅ **dnsmasq playbook**: Successfully updated DNS configuration  
✅ **DNS resolution**: All `*.denise.home` queries resolve to Traefik IP  
✅ **Traefik test playbook**: All tests passed (routing, DNS, end-to-end)  
✅ **User verification**: Changes reviewed and approved

## Test Results

```
✅ test.denise.home → 192.168.50.113
✅ argocd.denise.home → 192.168.50.113
✅ longhorn.denise.home → 192.168.50.113
✅ traefik.denise.home → 192.168.50.113
✅ whoami.denise.home → End-to-end test passed
```

## Next Steps

After merging, the next step is to update the IngressRoutes in k3s-apps repository to use the new `denise.home` domain (see k3s-apps#16).

## Files Changed

- `linux/playbooks/dnsmasq-setup.yml` - Updated domain variable
- `traefik/playbooks/traefik-test.yml` - Updated test hostname
- `docs/dns.md` - Updated all domain references
- `traefik/playbooks/traefik-setup.yml` - Updated domain variable
- `docs/traefik.md` - Updated examples

Closes #80