### PR TITLE
Fix: Exclude ingressroutes directory from argocd-apps Application

### DIFF
--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -238,6 +238,7 @@
               path: apps
               directory:
                 recurse: true
+                exclude: '**/ingressroutes/**'
             destination:
               server: https://kubernetes.default.svc
               namespace: "{{ argocd_namespace }}"


### PR DESCRIPTION
## Summary

- Adds `exclude: '**/ingressroutes/**'` to the `argocd-apps` Application to prevent resource conflicts
- Fixes continuous syncing issue where both `argocd-apps` and `traefik-ingressroutes` Applications were managing the same IngressRoutes

## Problem

After merging k3s-apps#17, the `traefik-ingressroutes` Application was constantly switching between "Synced" and "Syncing" status. 

ArgoCD logs showed `SharedResourceWarning` errors indicating that IngressRoutes were being managed by both:
1. `argocd-apps` (which recursively scans all of `apps/`)
2. `traefik-ingressroutes` (which specifically manages `apps/traefik/ingressroutes/`)

## Solution

Modified `argocd/playbooks/argocd-setup.yml` to exclude the `ingressroutes` directory pattern from the `argocd-apps` Application's directory scan.

## Verification

After applying the fix:
- ✅ All Applications remain "Synced" and stable
- ✅ SharedResourceWarning errors are gone
- ✅ IngressRoutes are only managed by `traefik-ingressroutes` Application
- ✅ All routes working: argocd.denise.home, longhorn.denise.home, traefik.denise.home

## Related Issues

- k3s-apps#16 - Centralize IngressRoute management
- k3s-apps#17 - PR that introduced the centralized IngressRoutes

## Note

This change has already been applied to the running cluster via `kubectl patch`. Merging this PR will ensure the fix is persisted in the Ansible playbook for future ArgoCD installations.