### PR TITLE
docs: add tests directory exclusion pattern to argocd-apps

### DIFF
--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -238,13 +238,20 @@
               path: apps
               directory:
                 recurse: true
-                # Exclude ingressroutes directories to prevent resource conflicts.
-                # The argocd-apps Application manages the traefik-ingressroutes Application manifest,
-                # but the traefik-ingressroutes Application itself manages the actual IngressRoute resources.
-                # Without this exclusion, both Applications would try to manage the same resources,
-                # causing SharedResourceWarning errors and continuous sync loops.
-                # See docs/argocd.md for more details on the app-of-apps pattern.
-                exclude: '**/ingressroutes/**'
+                # Exclude specific directories to prevent resource conflicts with dedicated Applications.
+                #
+                # **/ingressroutes/**: The argocd-apps Application manages the traefik-ingressroutes
+                # Application manifest, but traefik-ingressroutes itself manages the actual IngressRoute
+                # resources. Without this exclusion, both Applications would try to manage the same
+                # IngressRoutes, causing SharedResourceWarning errors and continuous sync loops.
+                #
+                # **/tests/**: Test resources (Jobs, PVCs) should be deployed manually on-demand,
+                # not automatically by argocd-apps. Test directories contain resources intended for
+                # verification during upgrades or troubleshooting, not for continuous deployment.
+                #
+                # Syntax: Brace-grouped glob pattern required for multiple exclusions in ArgoCD.
+                # See docs/argocd.md for more details on directory exclusions.
+                exclude: "{**/ingressroutes/**,**/tests/**}"
             destination:
               server: https://kubernetes.default.svc
               namespace: "{{ argocd_namespace }}"

--- a/docs/argocd.md
+++ b/docs/argocd.md
@@ -426,14 +426,63 @@ apps/traefik/
     └── traefik.yaml                    ← traefik-ingressroutes manages ✓
 ```
 
+### Multiple exclusion patterns
+
+ArgoCD's directory source supports excluding multiple patterns using **brace-grouped glob syntax**:
+
+```yaml
+exclude: "{**/ingressroutes/**,**/tests/**}"
+```
+
+This is equivalent to:
+- Exclude any file/directory matching `**/ingressroutes/**`
+- AND exclude any file/directory matching `**/tests/**`
+
+**Important:** Multiple patterns must use brace-grouped syntax. The following formats do NOT work:
+- ❌ YAML list: `['**/ingressroutes/**', '**/tests/**']`
+- ❌ Newline-separated: `**/ingressroutes/**\n**/tests/**`
+- ✅ Brace-grouped: `"{**/ingressroutes/**,**/tests/**}"`
+
+### Tests directory exclusion
+
+The `**/tests/**` exclusion prevents test resources from being automatically deployed:
+
+```
+apps/longhorn/
+├── application.yaml              ← argocd-apps manages ✓
+├── values.yaml                   ← Used by longhorn Application
+└── tests/                        ← argocd-apps IGNORES
+    ├── job.yaml                  ← Deploy manually when needed
+    ├── pvc.yaml                  ← Deploy manually when needed
+    └── README.md                 ← Instructions
+```
+
+**Why exclude tests:**
+- Test resources (Jobs, PVCs) are for **on-demand verification**, not continuous deployment
+- Used during: initial setup, major upgrades, troubleshooting storage issues
+- Automatically deploying tests wastes cluster resources
+- Tests can be run manually: `kubectl apply -f apps/longhorn/tests/`
+
+**Without this exclusion:** argocd-apps would continuously deploy test resources, creating unwanted Jobs and PVCs that consume storage and compute resources.
+
 ### When to add new exclusions
 
-Add a similar exclusion pattern if you create other centralized resource directories, such as:
-- `**/configmaps/**` — centralized ConfigMaps
-- `**/secrets/**` — centralized Secret manifests
-- `**/middleware/**` — centralized Traefik middlewares
+Add exclusion patterns for directories that should NOT be automatically deployed by argocd-apps:
 
-The rule: **If a dedicated Application manages a directory's contents, exclude that directory from argocd-apps.**
+**Managed by dedicated Applications:**
+- `**/ingressroutes/**` — managed by traefik-ingressroutes Application
+- `**/configmaps/**` — if using centralized ConfigMaps Application
+- `**/secrets/**` — if using centralized Secrets Application
+- `**/middleware/**` — if using centralized Traefik middleware Application
+
+**Manual deployment only:**
+- `**/tests/**` — test resources for on-demand verification
+- `**/examples/**` — example manifests for documentation
+- `**/templates/**` — template files requiring customization
+
+**The rule:** If resources should NOT be automatically deployed by argocd-apps, add an exclusion pattern.
+
+**Syntax reminder:** Use brace-grouped format for multiple patterns: `"{**/pattern1/**,**/pattern2/**}"`
 
 ## Troubleshooting Resource Conflicts
 


### PR DESCRIPTION
## Summary

- Codifies the `**/tests/**` exclusion pattern in argocd-setup.yml playbook
- Adds comprehensive documentation for ArgoCD directory exclusions
- Documents brace-grouped glob syntax requirement for multiple patterns

## Changes

### 1. argocd/playbooks/argocd-setup.yml

Updated the `exclude` pattern from single to multiple patterns:

**Before:**
```yaml
exclude: '**/ingressroutes/**'
```

**After:**
```yaml
exclude: "{**/ingressroutes/**,**/tests/**}"
```

Added detailed comments explaining:
- Why `**/ingressroutes/**` is excluded (managed by dedicated Application)
- Why `**/tests/**` is excluded (manual deployment only)
- Brace-grouped glob syntax requirement

### 2. docs/argocd.md

Added three new subsections:

**a) "Multiple exclusion patterns"**
- Documents brace-grouped glob syntax: `"{**/pattern1/**,**/pattern2/**}"`
- Shows what formats work vs. don't work
- Explains how multiple patterns are combined

**b) "Tests directory exclusion"**
- Visual diagram showing which files argocd-apps manages vs. ignores
- Explains why tests should be manual-only (on-demand verification)
- Documents manual deployment command: `kubectl apply -f apps/longhorn/tests/`

**c) Updated "When to add new exclusions"**
- Categorized into "Managed by dedicated Applications" vs. "Manual deployment only"
- Added examples: tests, examples, templates
- Included syntax reminder for brace-grouped format

## Why This Matters

Without the `**/tests/**` exclusion, argocd-apps continuously deploys test resources (Jobs, PVCs) from directories like `apps/longhorn/tests/`, causing:
- Unwanted resource consumption
- Confusion about production vs. test resources
- Continuous sync loops

This fix was previously applied directly to the cluster via `kubectl patch`. This PR codifies it in the playbook so it persists across ArgoCD redeployments.

## Testing

- ✅ Playbook syntax validated with `ansible-playbook --syntax-check`
- ✅ User validated with `ansible-playbook --check` (dry-run mode)
- ✅ No personal data in changes
- ✅ Documentation properly formatted

## Related

- k3s-apps#24 - Initial issue identifying test resource conflict
- k3s-apps#25 - Moved test-application.yaml into tests directory
- k3s-apps#26 - Removed automated test Application

Closes #85