### PR TITLE
Fix ArgoCD SharedResourceWarnings in app-of-apps pattern

### DIFF
--- a/argocd/playbooks/argocd-setup.yml
+++ b/argocd/playbooks/argocd-setup.yml
@@ -238,6 +238,12 @@
               path: apps
               directory:
                 recurse: true
+                # Include only Application manifests to prevent argocd-apps from managing workload resources.
+                # This ensures the app-of-apps pattern only creates child Applications, while each child
+                # Application manages its own workloads (DaemonSets, Deployments, Jobs, etc.).
+                # Without this, both argocd-apps and child Applications would try to manage the same
+                # resources, causing SharedResourceWarning errors.
+                include: '**/application.yaml'
                 # Exclude specific directories to prevent resource conflicts with dedicated Applications.
                 #
                 # **/ingressroutes/**: The argocd-apps Application manages the traefik-ingressroutes


### PR DESCRIPTION
## Summary

- Add `include: '**/application.yaml'` pattern to argocd-apps Application
- Prevents argocd-apps from managing workload resources (DaemonSets, Jobs, etc.)
- Ensures only child Applications manage their own workloads
- Resolves SharedResourceWarnings for intel-gpu-plugin and jellyfin resources

## Problem

The argocd-apps Application (app-of-apps pattern) was discovering and managing both:
1. Application manifests (e.g., `apps/intel-gpu-plugin/application.yaml`)
2. Workload resources (e.g., `apps/intel-gpu-plugin/daemonset.yaml`, `apps/jellyfin/hw-accel-config-job.yaml`)

This caused duplicate ownership where both argocd-apps AND individual Applications tried to manage the same resources, resulting in SharedResourceWarnings:
- `Application/intel-gpu-plugin` and `DaemonSet/intel-gpu-plugin`
- `Job/jellyfin-configure-hw-accel`

## Solution

Updated the argocd-apps Application in `argocd/playbooks/argocd-setup.yml` to include only `application.yaml` files using the `include` pattern. This ensures:
- argocd-apps only discovers and creates Application resources
- Individual Applications manage their own workloads
- No duplicate resource management = no SharedResourceWarnings

## Testing

After applying this change:
1. Run the argocd-setup.yml playbook to update the argocd-apps Application
2. Verify that child Applications (intel-gpu-plugin, jellyfin) still sync correctly
3. Check that SharedResourceWarnings are resolved in ArgoCD UI

Fixes denisecodes/k3s-apps#43