### PR TITLE
feat: enable remote access to homelab services via Tailscale DNS

### DIFF
--- a/docs/dns.md
+++ b/docs/dns.md
@@ -6,7 +6,7 @@ This document covers how to set up local DNS so homelab services are reachable b
 
 [dnsmasq](https://thekelleys.org.uk/dnsmasq/doc.html) runs on the homelab server and provides wildcard DNS resolution:
 
-- Any `*.denise.home` query resolves to the **Traefik LoadBalancer IP** (`<TRAEFIK_LOADBALANCER_IP>`)
+- Any `*.<your-domain>.home` query resolves to the **Traefik LoadBalancer IP** (`<TRAEFIK_LOADBALANCER_IP>`)
 - Traefik routes traffic to the appropriate service based on the hostname
 - All other DNS queries are forwarded to upstream resolvers (Cloudflare `1.1.1.1` and Google `8.8.8.8`)
 - The router's DHCP hands out the server's IP as the DNS server for all LAN clients
@@ -28,7 +28,7 @@ ansible-playbook -i linux/inventory/hosts-local.ini linux/playbooks/dnsmasq-setu
 The playbook will:
 - Install dnsmasq
 - Disable systemd-resolved (frees port 53)
-- Configure wildcard DNS for `*.denise.home`
+- Configure wildcard DNS for `*.<your-domain>.home`
 - Set upstream DNS forwarders (Cloudflare + Google)
 - Open UFW ports 53/tcp and 53/udp
 - Verify DNS resolution is working
@@ -72,7 +72,7 @@ After updating the router, devices need to renew their DHCP lease to pick up the
 From any device on your LAN:
 
 ```bash
-nslookup whoami.denise.home
+nslookup whoami.<your-domain>.home
 ```
 
 This should return the Traefik LoadBalancer IP (`<TRAEFIK_LOADBALANCER_IP>`). If it doesn't, check that:
@@ -82,13 +82,11 @@ This should return the Traefik LoadBalancer IP (`<TRAEFIK_LOADBALANCER_IP>`). If
 
 ## 5. Access services via hostname
 
-Services with Traefik IngressRoutes can be accessed via their configured hostnames:
+Services with Traefik IngressRoutes can be accessed via their configured hostnames. For example:
 
-- **ArgoCD**: http://argocd.denise.home
-- **Longhorn**: http://longhorn.denise.home
-- **Traefik Dashboard**: http://traefik.denise.home
+- `http://<service-name>.<your-domain>.home`
 
-To add a new service, create a Traefik IngressRoute in the k3s-apps repository. See examples in `apps/traefik/ingressroutes/` or the [IngressRoutes README](https://github.com/denisecodes/k3s-apps/blob/main/apps/traefik/ingressroutes/README.md).
+To add a new service, create a Traefik IngressRoute in the k3s-apps repository. See examples in `apps/traefik/ingressroutes/`.
 
 ## Configuration
 
@@ -96,10 +94,119 @@ Key variables in `linux/playbooks/dnsmasq-setup.yml`:
 
 | Variable | Default | Description |
 |---|---|---|
-| `homelab_domain` | `denise.home` | Wildcard domain for local services |
-| `traefik_ip` | `<TRAEFIK_LOADBALANCER_IP>` | Traefik LoadBalancer IP (all `*.denise.home` traffic routes here) |
+| `homelab_domain` | `<your-domain>.home` | Wildcard domain for local services |
+| `traefik_ip` | `<TRAEFIK_LOADBALANCER_IP>` | Traefik LoadBalancer IP (all `*.<your-domain>.home` traffic routes here) |
 | `upstream_dns_1` | `1.1.1.1` | Primary upstream DNS (Cloudflare) |
 | `upstream_dns_2` | `8.8.8.8` | Secondary upstream DNS (Google) |
+
+## Tailscale Integration
+
+Once you've set up local DNS, you can extend it to work with Tailscale for remote access. This allows you to use the same `*.<your-domain>.home` URLs whether you're at home or accessing remotely via Tailscale.
+
+### Overview
+
+**Standard setup (local network only):**
+- dnsmasq listens on localhost and LAN interface
+- Returns LAN IP for `*.<your-domain>.home` queries
+- Works only when connected to home WiFi
+
+**Tailscale-integrated setup (works everywhere):**
+- dnsmasq also listens on Tailscale interface
+- Returns Tailscale IP for `*.<your-domain>.home` queries
+- Tailscale MagicDNS forwards `*.<your-domain>.home` queries to your server via Split DNS
+- Works at home AND remotely via Tailscale
+- Same URLs everywhere
+
+### How DNS Resolution Works
+
+**When at home:**
+1. Device queries dnsmasq on LAN IP
+2. dnsmasq returns Tailscale IP
+3. Traffic routes via Tailscale's direct LAN connection (no tunnel overhead)
+4. Check with `tailscale status` — you'll see "direct <LAN_IP>:41641"
+
+**When remote via Tailscale:**
+1. Device queries Tailscale MagicDNS (`100.100.100.100`)
+2. Tailscale recognizes `*.<your-domain>.home` matches Split DNS rule
+3. Tailscale forwards query to your server's Tailscale IP
+4. dnsmasq on server returns Tailscale IP
+5. Traffic routes via Tailscale encrypted tunnel
+
+### Setup
+
+After completing the standard dnsmasq setup above, follow these steps:
+
+#### 1. Run the Tailscale DNS Integration Playbook
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini \
+  linux/playbooks/dnsmasq-tailscale-setup.yml \
+  --ask-become-pass
+```
+
+This updates dnsmasq to:
+- Listen on Tailscale interface in addition to localhost and LAN
+- Return Tailscale IP for all `*.<your-domain>.home` queries
+- Enable remote access while maintaining local network functionality
+
+#### 2. Configure Tailscale MagicDNS
+
+Configure Tailscale MagicDNS with Split DNS for `<your-domain>.home`. See [docs/tailscale.md - Remote Access via Tailscale DNS](tailscale.md#remote-access-via-tailscale-dns) for detailed step-by-step instructions.
+
+**Critical configuration requirement:**
+- ✅ Add Split DNS nameserver: `<YOUR_TAILSCALE_IP>` for domain `<your-domain>.home`
+- ❌ Do NOT add `<your-domain>.home` to "Search Domains"
+
+**Why this matters**: Adding `<your-domain>.home` as a search domain breaks browser DNS resolution. Command-line tools like `curl` and `dig` will work, but browsers will show `ERR_NAME_NOT_RESOLVED` errors because they try to query invalid domains like `<service-name>.<your-domain>.home.<your-domain>.home`.
+
+### What Changes
+
+The Tailscale integration updates your dnsmasq configuration:
+
+**Before (local network only):**
+```bash
+listen-address=127.0.0.1,<LAN_IP>
+address=/<your-domain>.home/<LAN_IP>
+```
+
+**After (works everywhere via Tailscale):**
+```bash
+listen-address=127.0.0.1,<LAN_IP>,<TAILSCALE_IP>
+address=/<your-domain>.home/<TAILSCALE_IP>
+```
+
+Key changes:
+- Adds Tailscale interface to listen addresses
+- Changes DNS responses to return Tailscale IP instead of LAN IP
+- Enables remote access via Tailscale MagicDNS
+
+### Why Return Tailscale IP for Home Network Too?
+
+You might wonder: "Why return the Tailscale IP even when I'm at home?"
+
+**Answer**: Tailscale is smart enough to use direct LAN connections when both devices are on the same network. Check `tailscale status` on your devices — you'll see "direct <LAN_IP>:41641" when at home.
+
+Benefits:
+- Same URLs work everywhere (no mental context switching)
+- No performance penalty (Tailscale uses LAN directly)
+- Simpler configuration (one dnsmasq instance, not two)
+- Easier troubleshooting (one DNS server to debug)
+
+### Performance Impact
+
+**Negligible**. Tailscale's WireGuard protocol adds microseconds of latency, and when you're at home, it uses direct LAN connections anyway (no tunnel overhead).
+
+### Rollback
+
+To revert to local-network-only DNS:
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini \
+  linux/playbooks/dnsmasq-setup.yml \
+  --ask-become-pass
+```
+
+This restores dnsmasq to the original configuration (listening only on localhost and LAN interface, returning LAN IP).
 
 ## Troubleshooting
 
@@ -114,3 +221,31 @@ Check that UFW allows port 53 and that your router DHCP is pointing to the serve
 
 **DNS queries are slow:**
 Check the dnsmasq log: `sudo tail -f /var/log/dnsmasq.log`. Ensure upstream DNS servers are reachable: `dig google.com @1.1.1.1`
+
+**DNS not resolving via Tailscale:**
+```bash
+# Verify dnsmasq is listening on Tailscale interface
+sudo ss -tlnp | grep :53
+# Should show your Tailscale IP (e.g., 100.x.x.x)
+
+# Test direct query to Tailscale IP
+dig <service-name>.<your-domain>.home @<YOUR_TAILSCALE_IP>
+# Should return the Tailscale IP
+```
+
+**Browser shows `ERR_NAME_NOT_RESOLVED` but command-line tools work:**
+
+This is the most common Tailscale DNS issue. See the detailed troubleshooting section in [docs/tailscale.md - Troubleshooting Remote Access](tailscale.md#troubleshooting-remote-access).
+
+**Quick fix**: Check if `<your-domain>.home` was added to Tailscale's "Search Domains" - if so, remove it!
+
+**MagicDNS not working:**
+```bash
+# Check MagicDNS status
+tailscale status
+# Should show: "MagicDNS: enabled"
+
+# Verify Split DNS configuration in Tailscale Admin Console
+# https://login.tailscale.com/admin/dns
+# Should show: <your-domain>.home (Split DNS) -> <YOUR_TAILSCALE_IP>
+```

--- a/docs/tailscale.md
+++ b/docs/tailscale.md
@@ -101,6 +101,292 @@ Or from the node directly:
 tailscale status
 ```
 
+## Remote Access via Tailscale DNS
+
+Once Tailscale is installed and authenticated, you can access your homelab services using the same `*.<your-domain>.home` URLs whether you're at home or connected remotely via Tailscale.
+
+### Why DNS Integration?
+
+Without DNS integration, remote access requires using IP:port combinations (e.g., `http://<TAILSCALE_IP>:30080`). With DNS integration, you can use the same friendly URLs everywhere:
+
+- **At home**: `http://<service-name>.<your-domain>.home`
+- **Remote via Tailscale**: `http://<service-name>.<your-domain>.home` (same URL!)
+
+### Prerequisites
+
+- Tailscale installed and authenticated on homelab nodes (steps 1-4 above)
+- dnsmasq configured for local DNS (see [docs/dns.md](dns.md))
+- Traefik accessible on Tailscale IP (verify with: `curl http://<TAILSCALE_IP>/`)
+
+### 1. Update dnsmasq for Tailscale
+
+Run the Tailscale DNS setup playbook to configure dnsmasq to listen on the Tailscale interface and return the Tailscale IP for all `*.<your-domain>.home` queries:
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini \
+  linux/playbooks/dnsmasq-tailscale-setup.yml \
+  --ask-become-pass
+```
+
+This playbook will:
+- Detect your server's Tailscale IP automatically
+- Update dnsmasq to listen on localhost, LAN interface, and Tailscale interface
+- Configure wildcard DNS to return the Tailscale IP for `*.<your-domain>.home`
+- Verify the configuration is working
+
+**Expected output:**
+```
+DNS test: test.<your-domain>.home resolves to <TAILSCALE_IP>.
+✅ Wildcard DNS is working correctly - resolving to Tailscale IP.
+```
+
+### 2. Configure Tailscale MagicDNS
+
+Enable MagicDNS and configure Split DNS to forward `*.<your-domain>.home` queries to your homelab server:
+
+1. **Go to Tailscale DNS Settings**
+   - Navigate to [https://login.tailscale.com/admin/dns](https://login.tailscale.com/admin/dns)
+
+2. **Enable MagicDNS**
+   - If not already enabled, toggle "MagicDNS" to ON
+   - This allows Tailscale to manage DNS for your tailnet
+
+3. **Add Split DNS Nameserver**
+   - In the "Nameservers" section, you should see your tailnet domain (e.g., `tail7b6c16.ts.net`)
+   - Below that, click "Add nameserver"
+   - A dialog will appear - select the **"Split DNS"** option
+   - Enter:
+     - **Domain**: `<your-domain>.home`
+     - **Nameserver**: Your server's Tailscale IP (e.g., `100.x.x.x`)
+       - To find this: Run `tailscale ip -4` on your server, or check the playbook output from step 1
+   - Click "Add" or "Save"
+   
+   You should now see an entry in the Nameservers section like:
+   ```
+   <your-domain>.home     Split DNS
+   100.x.x.x
+   ```
+   
+   This configures Tailscale to forward all `*.<your-domain>.home` queries to your homelab server's dnsmasq.
+
+4. **⚠️ CRITICAL: Verify Search Domains**
+   - Scroll down to the "Search Domains" section
+   - **Verify `<your-domain>.home` is NOT listed here**
+   - You should only see your Tailscale domain (e.g., `tail7b6c16.ts.net`)
+   
+   **Why this matters**: If `<your-domain>.home` appears in "Search Domains", remove it immediately!
+   - Search domains are for appending to single-word queries (e.g., `server` → `server.company.com`)
+   - Having `<your-domain>.home` as a search domain breaks browser DNS resolution
+   - Browsers will try invalid queries like `<service-name>.<your-domain>.home.<your-domain>.home`
+   - This causes `ERR_NAME_NOT_RESOLVED` errors even though command-line tools work
+   
+   **To remove**: Click the X or remove button next to `<your-domain>.home` in the Search Domains section
+
+5. **Wait for DNS Propagation**
+   - DNS changes typically propagate within 10-20 seconds
+   - Tailscale clients will automatically pick up the new configuration
+
+### 3. Verify from Your Devices
+
+**From your Mac** (while connected to Tailscale):
+
+```bash
+# Test DNS resolution
+dig <service-name>.<your-domain>.home
+# Should return your Tailscale IP (e.g., 100.x.x.x)
+
+# Verify DNS configuration (optional)
+scutil --dns | grep "search domain"
+# Should NOT show <your-domain>.home in the search domains list
+```
+
+**From your iPhone** (connected to Tailscale, NOT on home WiFi):
+
+Open Safari and navigate to your services using the `*.<your-domain>.home` URLs. For example:
+- `http://<service-name>.<your-domain>.home` (replace with your actual service name)
+
+All services with IngressRoutes configured for `*.<your-domain>.home` should load successfully!
+
+### How It Works
+
+**When at home:**
+- Your device queries dnsmasq on the homelab server
+- dnsmasq returns the Tailscale IP (e.g., `100.x.x.x`)
+- Traffic routes via Tailscale's direct LAN connection (no tunnel overhead)
+- Check with `tailscale status` — you'll see "direct <LAN_IP>:41641"
+
+**When remote via Tailscale:**
+- Your device queries dnsmasq via Tailscale MagicDNS
+- dnsmasq returns the Tailscale IP (e.g., `100.x.x.x`)
+- Traffic routes via Tailscale's encrypted WireGuard tunnel
+- Same URLs, seamless experience
+
+### Troubleshooting Remote Access
+
+#### Browser Shows `ERR_NAME_NOT_RESOLVED` for `*.<your-domain>.home`
+
+**Symptoms:**
+- Command-line tools work: `curl http://<service-name>.<your-domain>.home` succeeds
+- DNS resolution works: `dig <service-name>.<your-domain>.home` returns correct IP
+- Browser fails: Shows "DNS address could not be found" or `ERR_NAME_NOT_RESOLVED`
+
+**Root Cause:**
+`<your-domain>.home` was incorrectly added to Tailscale's "Search Domains" section. This causes browsers to append the search domain to queries, creating invalid domains like `<service-name>.<your-domain>.home.<your-domain>.home`.
+
+**Solution:**
+
+1. **Check Tailscale DNS Configuration**
+   - Go to https://login.tailscale.com/admin/dns
+   - Scroll to "Search Domains" section
+   - **If `<your-domain>.home` is listed**: Click the X or remove button to delete it
+   - **Keep only**: Your Tailscale domain (e.g., `tail7b6c16.ts.net`) and any other legitimate search domains
+
+2. **Verify Split DNS Configuration Still Exists**
+   - In the "Nameservers" section, you should still see:
+     ```
+     <your-domain>.home     Split DNS
+     <YOUR_TAILSCALE_IP>
+     ```
+   - This is correct and should remain
+
+3. **Wait and Test**
+   ```bash
+   # Wait 10-20 seconds for DNS changes to propagate
+   
+   # Verify search domains (macOS)
+   scutil --dns | grep "search domain"
+   # Should NOT show <your-domain>.home
+   
+   # Test in browser
+   open http://<service-name>.<your-domain>.home
+   ```
+
+4. **If Still Not Working**
+   - Clear browser DNS cache:
+     - **Chrome**: Visit `chrome://net-internals/#dns` → Click "Clear host cache"
+     - **Safari**: Clear all website data or use Private Browsing
+   - Restart Tailscale client on your device
+   - Try opening `http://<service-name>.<your-domain>.home` in incognito/private mode
+
+#### DNS Not Resolving on Tailscale
+
+**Symptoms:**
+- `dig <service-name>.<your-domain>.home` returns `NXDOMAIN` or no answer
+
+**Solution:**
+```bash
+# Check MagicDNS is enabled
+tailscale status
+# Should show: "MagicDNS: enabled"
+
+# Test direct query to your server
+dig <service-name>.<your-domain>.home @<YOUR_TAILSCALE_IP>
+# Should return the Tailscale IP
+
+# If direct query works but MagicDNS doesn't:
+# - Verify Split DNS is configured (see step 2 above)
+# - Check that <your-domain>.home is NOT in search domains
+```
+
+#### DNS Resolves But Connection Times Out
+
+**Symptoms:**
+- DNS resolves correctly: `dig <service-name>.<your-domain>.home` returns `100.x.x.x`
+- Browser shows "Took too long to respond" or connection timeout
+
+**Possible Causes:**
+
+1. **Tailscale Not Connected**
+   ```bash
+   # Check Tailscale status
+   tailscale status
+   # Should show "Online" and list your server
+   ```
+
+2. **Server Not Reachable**
+   ```bash
+   # Test connectivity to server
+   ping <YOUR_TAILSCALE_IP>
+   
+   # Test SSH
+   ssh <user>@<YOUR_TAILSCALE_IP>
+   ```
+
+3. **Traefik Not Accessible**
+   ```bash
+   # Verify Traefik is accessible on Tailscale IP
+   curl -I http://<YOUR_TAILSCALE_IP>/
+   # Should return HTTP 404 (Traefik responding)
+   
+   # Test with host header
+   curl -I -H "Host: <service-name>.<your-domain>.home" http://<YOUR_TAILSCALE_IP>/
+   # Should return HTTP 200 or redirect
+   ```
+
+4. **dnsmasq Not Running on Server**
+   ```bash
+   # SSH to server and check
+   ssh <user>@<YOUR_TAILSCALE_IP>
+   sudo systemctl status dnsmasq
+   # Should show "active (running)"
+   ```
+
+#### Services Work at Home But Not Remotely
+
+**Symptoms:**
+- `http://<service-name>.<your-domain>.home` works on home WiFi
+- Same URL fails when connected via Tailscale on different network
+
+**Solution:**
+This indicates Tailscale Split DNS is not configured correctly. Follow the "Configure Tailscale MagicDNS" section above, specifically:
+- Ensure Split DNS nameserver is added for `<your-domain>.home` domain
+- Verify `<your-domain>.home` is NOT in search domains
+- Test with `dig <service-name>.<your-domain>.home` - should return Tailscale IP, not local IP
+
+#### Verify DNS Configuration (macOS)
+
+To check your DNS configuration is correct:
+
+```bash
+# View all DNS resolvers
+scutil --dns | head -30
+
+# Expected output for resolver #1:
+#   search domain[0] : tail<random>.ts.net
+#   search domain[1] : lan (or your network domain)
+#   nameserver[0] : 100.100.100.100 (Tailscale MagicDNS)
+
+# Key point: <your-domain>.home should NOT appear in search domains
+
+# Test DNS resolution
+dig <service-name>.<your-domain>.home
+# Should return: ;; ANSWER SECTION: <service-name>.<your-domain>.home. 0 IN A <TAILSCALE_IP>
+```
+
+#### Home Network DNS Still Works
+
+After updating dnsmasq, your home network devices should continue to work normally. The change from returning the LAN IP to returning the Tailscale IP is transparent because:
+- Tailscale uses direct LAN connections when both devices are on the same network
+- Traefik listens on all interfaces, including the Tailscale interface
+- Performance impact is negligible (WireGuard adds microseconds)
+- Check with `tailscale status` — you'll see "direct <LAN_IP>:41641" when at home
+
+### Rollback
+
+If you need to revert to the original dnsmasq configuration:
+
+```bash
+ansible-playbook -i linux/inventory/hosts-local.ini \
+  linux/playbooks/dnsmasq-setup.yml \
+  --ask-become-pass
+```
+
+This will restore dnsmasq to listen only on localhost and the LAN interface, returning the LAN IP for `*.<your-domain>.home` queries.
+
+**Fallback access method**: You can always access services via NodePort even if DNS is not working:
+- ArgoCD: `http://<TAILSCALE_IP>:30080`
+- Longhorn: `http://<TAILSCALE_IP>:<LONGHORN_NODEPORT>`
+
 ## Configuration reference
 
 | Variable | File | Description |

--- a/linux/playbooks/dnsmasq-tailscale-setup.yml
+++ b/linux/playbooks/dnsmasq-tailscale-setup.yml
@@ -1,0 +1,226 @@
+---
+# Updates dnsmasq to support remote access via Tailscale DNS (split-horizon).
+# This playbook configures dnsmasq to listen on the Tailscale interface and return
+# the Tailscale IP for all *.denise.home queries, enabling unified URLs whether
+# at home or accessing remotely via Tailscale.
+#
+# Prerequisites:
+#   - Tailscale installed and authenticated on homelab nodes
+#   - dnsmasq already configured for local DNS (via dnsmasq-setup.yml)
+#   - Traefik accessible on Tailscale IP (verify with: curl http://<TAILSCALE_IP>/)
+#
+# Before running:
+#   1. Ensure linux/inventory/hosts-local.ini has traefik_loadbalancer_ip set
+#   2. Verify Tailscale is running: ssh <node> "tailscale status"
+#
+# Run with:
+#   ansible-playbook -i linux/inventory/hosts-local.ini \
+#     linux/playbooks/dnsmasq-tailscale-setup.yml --ask-become-pass
+#
+# After running:
+#   - Configure Tailscale MagicDNS (see docs/tailscale.md)
+#   - Test DNS resolution: dig argocd.denise.home @<TAILSCALE_IP>
+#
+# Rollback:
+#   ansible-playbook -i linux/inventory/hosts-local.ini \
+#     linux/playbooks/dnsmasq-setup.yml --ask-become-pass
+
+- name: Configure dnsmasq for Tailscale remote access
+  hosts: master
+  become: true
+
+  vars:
+    homelab_domain: "denise.home"
+    # Upstream DNS servers — used for all queries except *.denise.home
+    upstream_dns_1: "1.1.1.1"
+    upstream_dns_2: "8.8.8.8"
+
+  tasks:
+
+    # -- 1. Verify prerequisites ------------------------------------------------
+    - name: Check that traefik_loadbalancer_ip is defined
+      ansible.builtin.assert:
+        that:
+          - traefik_loadbalancer_ip is defined
+          - traefik_loadbalancer_ip != ""
+        fail_msg: |
+          ERROR: traefik_loadbalancer_ip is not set!
+          
+          Please set it in your inventory file (linux/inventory/hosts-local.ini):
+          
+          [homelab:vars]
+          traefik_loadbalancer_ip=<YOUR_TRAEFIK_IP>
+          
+          This should be the external IP of your Traefik LoadBalancer service.
+          Find it with: kubectl get svc -n traefik
+        success_msg: "traefik_loadbalancer_ip is set to {{ traefik_loadbalancer_ip }}"
+
+    - name: Check that Tailscale is installed
+      ansible.builtin.command: which tailscale
+      register: tailscale_check
+      changed_when: false
+      failed_when: tailscale_check.rc != 0
+
+    - name: Check that Tailscale is running
+      ansible.builtin.command: tailscale status --json
+      register: tailscale_status
+      changed_when: false
+      failed_when: tailscale_status.rc != 0
+
+    - name: Verify Tailscale is authenticated
+      ansible.builtin.assert:
+        that:
+          - "'BackendState' in tailscale_status.stdout"
+          - "(tailscale_status.stdout | from_json).BackendState == 'Running'"
+        fail_msg: |
+          ERROR: Tailscale is not authenticated or running!
+          
+          Please authenticate Tailscale first:
+            ansible-playbook -i linux/inventory/hosts-local.ini \
+              linux/playbooks/tailscale-auth.yml --ask-become-pass --ask-vault-pass
+        success_msg: "Tailscale is running and authenticated"
+
+    # -- 2. Get network information ---------------------------------------------
+    - name: Get server LAN IP
+      ansible.builtin.set_fact:
+        server_ip: "{{ ansible_facts['default_ipv4']['address'] }}"
+
+    - name: Get Tailscale IP
+      ansible.builtin.command: tailscale ip -4
+      register: tailscale_ip_result
+      changed_when: false
+
+    - name: Set Tailscale IP fact
+      ansible.builtin.set_fact:
+        tailscale_ip: "{{ tailscale_ip_result.stdout | trim }}"
+
+    - name: Display network configuration
+      ansible.builtin.debug:
+        msg: |
+          Network configuration:
+            - Server LAN IP: {{ server_ip }}
+            - Tailscale IP: {{ tailscale_ip }}
+            - Traefik LoadBalancer IP: {{ traefik_loadbalancer_ip }}
+          
+          dnsmasq will be configured to:
+            - Listen on: 127.0.0.1, {{ server_ip }}, {{ tailscale_ip }}
+            - Return {{ tailscale_ip }} for all *.{{ homelab_domain }} queries
+
+    # -- 3. Update dnsmasq configuration ----------------------------------------
+    - name: Write dnsmasq configuration for Tailscale remote access
+      ansible.builtin.copy:
+        content: |
+          # Managed by Ansible — dnsmasq-tailscale-setup.yml
+          # Updated for remote access via Tailscale DNS (split-horizon)
+          
+          # Wildcard DNS: all *.{{ homelab_domain }} queries resolve to Tailscale IP
+          # This enables unified URLs whether at home or accessing remotely via Tailscale
+          address=/{{ homelab_domain }}/{{ tailscale_ip }}
+
+          # Upstream DNS servers for everything else
+          server={{ upstream_dns_1 }}
+          server={{ upstream_dns_2 }}
+
+          # Listen on localhost, LAN interface, and Tailscale interface
+          # This allows DNS queries from:
+          #   - Local processes (127.0.0.1)
+          #   - Home network devices ({{ server_ip }})
+          #   - Tailscale-connected devices ({{ tailscale_ip }})
+          listen-address=127.0.0.1,{{ server_ip }},{{ tailscale_ip }}
+          bind-interfaces
+
+          # Don't read /etc/resolv.conf for upstream servers (we set them above)
+          no-resolv
+
+          # Cache DNS queries (default 150, increase for a small LAN)
+          cache-size=1000
+
+          # Log DNS queries (useful for debugging, disable later if noisy)
+          log-queries
+          log-facility=/var/log/dnsmasq.log
+        dest: /etc/dnsmasq.conf
+        owner: root
+        group: root
+        mode: '0644'
+      notify: Restart dnsmasq
+
+    # -- 4. Ensure dnsmasq is running -------------------------------------------
+    - name: Enable and start dnsmasq
+      ansible.builtin.service:
+        name: dnsmasq
+        state: started
+        enabled: true
+
+    # -- 5. Verify configuration ------------------------------------------------
+    - name: Flush handlers to restart dnsmasq
+      ansible.builtin.meta: flush_handlers
+
+    - name: Wait for dnsmasq to be ready
+      ansible.builtin.pause:
+        seconds: 3
+
+    - name: Test wildcard DNS resolution
+      ansible.builtin.command: dig +short test.{{ homelab_domain }} @127.0.0.1
+      register: dns_test
+      changed_when: false
+
+    - name: Display DNS test result
+      ansible.builtin.debug:
+        msg: |
+          DNS test: test.{{ homelab_domain }} resolves to {{ dns_test.stdout | trim }}.
+          {% if dns_test.stdout | trim == tailscale_ip %}
+          ✅ Wildcard DNS is working correctly - resolving to Tailscale IP.
+          {% else %}
+          ⚠️  WARNING: Expected {{ tailscale_ip }} but got {{ dns_test.stdout | trim }}. Check dnsmasq configuration.
+          {% endif %}
+
+    - name: Test DNS resolution via Tailscale IP
+      ansible.builtin.command: dig +short argocd.{{ homelab_domain }} @{{ tailscale_ip }}
+      register: dns_test_tailscale
+      changed_when: false
+
+    - name: Display Tailscale DNS test result
+      ansible.builtin.debug:
+        msg: |
+          DNS test via Tailscale IP: argocd.{{ homelab_domain }} resolves to {{ dns_test_tailscale.stdout | trim }}.
+          {% if dns_test_tailscale.stdout | trim == tailscale_ip %}
+          ✅ DNS queries via Tailscale interface are working correctly.
+          {% else %}
+          ⚠️  WARNING: Expected {{ tailscale_ip }} but got {{ dns_test_tailscale.stdout | trim }}.
+          {% endif %}
+
+    # -- 6. Display next steps --------------------------------------------------
+    - name: Display next steps
+      ansible.builtin.debug:
+        msg: |
+          ✅ dnsmasq is now configured for Tailscale remote access!
+          
+          Next steps:
+          
+          1. Configure Tailscale MagicDNS:
+             - Go to https://login.tailscale.com/admin/dns
+             - Enable "MagicDNS"
+             - Add global nameserver: {{ tailscale_ip }}
+             - Add search domain: {{ homelab_domain }}
+          
+          2. Test from a remote device (connected to Tailscale, NOT on home WiFi):
+             - Test DNS: dig argocd.{{ homelab_domain }}
+             - Test browser: http://argocd.{{ homelab_domain }}
+          
+          3. Verify all services work:
+             - ArgoCD: http://argocd.{{ homelab_domain }}
+             - Longhorn: http://longhorn.{{ homelab_domain }}
+             - Traefik: http://traefik.{{ homelab_domain }}
+             - Jellyfin: http://jellyfin.{{ homelab_domain }}
+             - Nextcloud: http://nextcloud.{{ homelab_domain }}
+          
+          Documentation: See docs/tailscale.md for detailed setup guide.
+          
+          Rollback: ansible-playbook -i linux/inventory/hosts-local.ini \
+                    linux/playbooks/dnsmasq-setup.yml --ask-become-pass
+
+  handlers:
+    - name: Restart dnsmasq
+      ansible.builtin.service:
+        name: dnsmasq
+        state: restarted


### PR DESCRIPTION
## Summary

- Configure dnsmasq to listen on Tailscale interface and return Tailscale IP for `*.<domain>.home` queries
- Enable Tailscale MagicDNS with Split DNS configuration for seamless remote access
- Document critical configuration requirement: domain must NOT be added to Tailscale search domains
- Provide comprehensive troubleshooting guide for browser DNS resolution issues

## Implementation

**New Playbook:**
- `linux/playbooks/dnsmasq-tailscale-setup.yml` - Configures dnsmasq for Tailscale remote access
  - Auto-detects Tailscale IP dynamically
  - Updates dnsmasq to listen on Tailscale interface
  - Configures wildcard DNS to return Tailscale IP
  - Includes verification tests

**Documentation Updates:**
- `docs/tailscale.md` - Complete guide for Tailscale MagicDNS Split DNS configuration
  - Accurate step-by-step instructions for Split DNS setup
  - Critical warning about NOT adding domain to search domains
  - Comprehensive troubleshooting section covering browser DNS issues
- `docs/dns.md` - Tailscale integration section explaining the setup
  - How DNS resolution works (home vs remote)
  - Configuration changes and rationale
  - Enhanced troubleshooting

## Key Discovery

During implementation, discovered that adding the domain to Tailscale's "Search Domains" breaks browser DNS resolution (causes `ERR_NAME_NOT_RESOLVED`) while command-line tools (`curl`, `dig`) continue to work. This is now prominently documented with:
- Warning in configuration steps
- Dedicated troubleshooting section
- Verification commands for macOS
- Step-by-step fix instructions

## Testing

Verified all services accessible remotely via Tailscale using `*.<domain>.home` URLs:
- ✅ Services accessible from laptop on different WiFi network
- ✅ Services accessible from iPhone via Tailscale
- ✅ DNS resolution works correctly
- ✅ Services continue working on home network
- ✅ Traefik routing works via Tailscale IP

Also verified services continue working on home network with no performance impact (Tailscale uses direct LAN connections when at home).

## Related Changes

Companion PR in k3s-apps repository:
- Removed redundant Jellyfin Tailscale machine name IngressRoute
- Simplified to single `<service>.<domain>.home` IngressRoute per service

Closes #91